### PR TITLE
Unquote command line arguments for Helm upgrade

### DIFF
--- a/teamcity-kubernetes-plugin-agent/src/main/java/jetbrains/buildServer/helm/UpgradeArgumentsProvider.java
+++ b/teamcity-kubernetes-plugin-agent/src/main/java/jetbrains/buildServer/helm/UpgradeArgumentsProvider.java
@@ -22,11 +22,9 @@ public class UpgradeArgumentsProvider implements HelmCommandArgumentsProvider {
     @NotNull
     @Override
     public List<String> getArguments(@NotNull Map<String, String> runnerParameters) {
-        List<String> result = new LinkedList<String>();
-        result.add(HELM_UPGRADE_COMMAND);
-        result.add(StringUtil.emptyIfNull(runnerParameters.get(HELM_UPGRADE_COMMAND_NAME + RELEASE_NAME)));
-        result.add(StringUtil.emptyIfNull(runnerParameters.get(HELM_UPGRADE_COMMAND_NAME + CHART)));
-        result.add(StringUtil.emptyIfNull(runnerParameters.get(HELM_UPGRADE_COMMAND_NAME + ADDITIONAL_FLAGS)));
-        return result;
+        String release = runnerParameters.get(HELM_UPGRADE_COMMAND_NAME + RELEASE_NAME);
+        String chart = runnerParameters.get(HELM_UPGRADE_COMMAND_NAME + CHART);
+        String additionalFlags = runnerParameters.get(HELM_UPGRADE_COMMAND_NAME + ADDITIONAL_FLAGS);
+        return StringUtil.splitCommandArgumentsAndUnquote(String.format("%s %s %s %s", HELM_UPGRADE_COMMAND, StringUtil.emptyIfNull(release), StringUtil.emptyIfNull(chart), StringUtil.emptyIfNull(additionalFlags)));
     }
 }


### PR DESCRIPTION
Enclosing additional command line arguments for helm upgrade in quotes made it accept only one flag (--wait --timeout 20 would be seen as "--wait --timeout 20", which is an unrecognized flag).
This commit changes the behavior for upgrade to be similar to helm install by running splitCommandArgumentsAndUnquote on the string returned.