### PR TITLE
Add original container names to generated names

### DIFF
--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/podSpec/CustomTemplatePodTemplateProvider.java
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/podSpec/CustomTemplatePodTemplateProvider.java
@@ -76,7 +76,7 @@ public class CustomTemplatePodTemplateProvider implements BuildAgentPodTemplateP
 
         PodSpec spec = podTemplateSpec.getSpec();
         for (Container container : spec.getContainers()){
-            container.setName(instanceName);
+            container.setName(container.getName() + "-" + instanceName);
 
             Map<String, String> patchedEnvData = new HashMap<>();
             for (EnvVar env : container.getEnv()){


### PR DESCRIPTION
When using the custom pod template Pod Specification option you can't specify more than one container.  The unique instance name that is generated will be set as the name for all containers in the pod specification.  This creates a conflict and the duplicate containers will fail to start.

I added the original container name as a prefix to the generated name.