### PR TITLE
Add additional AWS authorization options for EKS auth

### DIFF
--- a/teamcity-kubernetes-plugin-server/pom.xml
+++ b/teamcity-kubernetes-plugin-server/pom.xml
@@ -155,6 +155,12 @@
       <version>1.11.475</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.2</version>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeParametersConstants.java
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeParametersConstants.java
@@ -49,6 +49,9 @@ public class KubeParametersConstants {
 
     public static final String EKS_ACCESS_ID = "eksAccessId";
     public static final String EKS_SECRET_KEY = "eksSecretKey";
+    public static final String EKS_USE_INSTANCE_PROFILE = "eksUseInstanceProfile";
+    public static final String EKS_ASSUME_IAM_ROLE = "eksAssumeIAMRole";
+    public static final String EKS_IAM_ROLE_ARN = "eksIAMRoleArn";
     public static final String EKS_REGION = "eksRegion";
     public static final String EKS_CLUSTER_NAME = "eksClusterName";
 
@@ -156,6 +159,14 @@ public class KubeParametersConstants {
 
     public String getEksSecretKey() {
         return EKS_SECRET_KEY;
+    }
+
+    public String getEksUseInstanceProfile() { return EKS_USE_INSTANCE_PROFILE; }
+
+    public String getEksAssumeIamRole() { return EKS_ASSUME_IAM_ROLE; }
+
+    public String getEksIAMRoleArn() {
+        return EKS_IAM_ROLE_ARN;
     }
 
     public String getEksRegion() {

--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/auth/EKSAuthStrategy.kt
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/auth/EKSAuthStrategy.kt
@@ -47,7 +47,7 @@ class EKSAuthStrategy(myTimeService: TimeService) : RefreshableStrategy<EKSData>
                 .build() as AWSSecurityTokenServiceClient
 
         val token = generateToken(dataHolder.clusterName, Date(), tokenService, credentials, "https", "sts.amazonaws.com")
-        return Pair(token, 60*12) // expire time = 12 minutes
+        return Pair(token, 60*15) // expire time = 15 minutes
     }
 
     override fun createKey(dataHolder: EKSData): Pair<String, String> {
@@ -76,7 +76,7 @@ class EKSAuthStrategy(myTimeService: TimeService) : RefreshableStrategy<EKSData>
                     .build() as AWSSecurityTokenServiceClient
             STSAssumeRoleSessionCredentialsProvider.Builder(dataHolder.iamRoleArn, "teamcity-kubernetes-plugin-session")
                     .withStsClient(stsClient)
-                    .withRoleSessionDurationSeconds(60 * 12)
+                    .withRoleSessionDurationSeconds(60 * 15)
                     .build() as STSAssumeRoleSessionCredentialsProvider
         } else {
             baseCreds

--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/auth/EKSAuthStrategy.kt
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/auth/EKSAuthStrategy.kt
@@ -60,7 +60,7 @@ class EKSAuthStrategy(myTimeService: TimeService) : RefreshableStrategy<EKSData>
 
     private fun getAwsCredentialProvider(dataHolder: EKSData): AWSCredentialsProvider {
         // Only initialize the credential provider once. Static creds never change and the AssumeRole handles refreshing credentials itself
-        if (credentialsProvider == null) return credentialsProvider!!
+        if (credentialsProvider != null) return credentialsProvider!!
 
         var baseCreds = if (dataHolder.useInstanceProfile) {
             InstanceProfileCredentialsProvider.getInstance()

--- a/teamcity-kubernetes-plugin-server/src/main/resources/buildServerResources/editProfile.jsp
+++ b/teamcity-kubernetes-plugin-server/src/main/resources/buildServerResources/editProfile.jsp
@@ -150,18 +150,35 @@
             <span id="error_secure:${cons.oidcRefreshToken}" class="error"></span>
         </td>
     </tr>
-
     <tr class="hidden eks auth-ui">
+        <th><label for="${cons.eksUseInstanceProfile}">Use Server Instance Profile: </label></th>
+        <td><props:checkboxProperty name="${cons.eksUseInstanceProfile}" className="longField"/>
+            <span id="error_${cons.eksUseInstanceProfile}" class="error"></span>
+        </td>
+    </tr>
+    <tr class="hidden eks auth-ui aws-credential">
         <th><label for="${cons.eksAccessId}">Access ID: <l:star/></label></th>
         <td><props:textProperty name="${cons.eksAccessId}" className="longField"/>
             <span id="error_${cons.eksAccessId}" class="error"></span>
         </td>
     </tr>
-    <tr class="hidden eks auth-ui">
+    <tr class="hidden eks auth-ui aws-credential">
         <th><label for="secure:${cons.eksSecretKey}">Secret Key: <l:star/></label></th>
         <td>
             <props:passwordProperty name="secure:${cons.eksSecretKey}" className="longField"/>
             <span id="error_secure:${cons.eksSecretKey}" class="error"></span>
+        </td>
+    </tr>
+    <tr class="hidden eks auth-ui">
+        <th><label for="${cons.eksAssumeIamRole}">Assume an IAM Role: </label></th>
+        <td><props:checkboxProperty name="${cons.eksAssumeIamRole}" className="longField"/>
+            <span id="error_${cons.eksAssumeIamRole}" class="error"></span>
+        </td>
+    </tr>
+    <tr class="hidden eks aws-iam">
+        <th><label for="${cons.eksIAMRoleArn}">IAM Role ARN: <l:star/></label></th>
+        <td><props:textProperty name="${cons.eksIAMRoleArn}" className="longField"/>
+            <span id="error_${cons.eksIAMRoleArn}" class="error"></span>
         </td>
     </tr>
     <tr class="hidden eks auth-ui">
@@ -170,7 +187,6 @@
             <span id="error_${cons.eksClusterName}" class="error"></span>
         </td>
     </tr>
-
     <tr>
         <th class="noBorder"></th>
         <td class="noBorder">

--- a/teamcity-kubernetes-plugin-server/src/main/resources/buildServerResources/kubeSettings.js
+++ b/teamcity-kubernetes-plugin-server/src/main/resources/buildServerResources/kubeSettings.js
@@ -344,19 +344,25 @@ if(!BS.Kube.ProfileSettingsForm) BS.Kube.ProfileSettingsForm = OO.extend(BS.Plug
     },
 
     _toggleEKSCredentials: function () {
-        var checked = this.$eksUseInstanceProfile.is(":checked");
-        $j('.eks.aws-credential').toggleClass('hidden', checked);
+        var selectedStrategyId = this.$authStrategySelector.val();
+        if (selectedStrategyId == "eks") {
+            var checked = this.$eksUseInstanceProfile.is(":checked");
+            $j('.eks.aws-credential').toggleClass('hidden', checked);
 
-        //workaround for TW-51797
-        BS.MultilineProperties.updateVisible();
+            //workaround for TW-51797
+            BS.MultilineProperties.updateVisible();
+        }
     },
 
     _toggleEKSIAM: function () {
-        var checked = this.$eksAssumeIAMRole.is(":checked");
-        $j('.eks.aws-iam').toggleClass('hidden', !checked);
+        var selectedStrategyId = this.$authStrategySelector.val();
+        if (selectedStrategyId == "eks") {
+            var checked = this.$eksAssumeIAMRole.is(":checked");
+            $j('.eks.aws-iam').toggleClass('hidden', !checked);
 
-        //workaround for TW-51797
-        BS.MultilineProperties.updateVisible();
+            //workaround for TW-51797
+            BS.MultilineProperties.updateVisible();
+        }
     },
 
     _togglePodSpecMode: function () {

--- a/teamcity-kubernetes-plugin-server/src/main/resources/buildServerResources/kubeSettings.js
+++ b/teamcity-kubernetes-plugin-server/src/main/resources/buildServerResources/kubeSettings.js
@@ -55,6 +55,8 @@ if(!BS.Kube.ProfileSettingsForm) BS.Kube.ProfileSettingsForm = OO.extend(BS.Plug
         this.$imagesTableWrapper = $j('.imagesTableWrapper');
 
         this.$authStrategySelector = $j('#authStrategy');
+        this.$eksUseInstanceProfile = $j('#eksUseInstanceProfile');
+        this.$eksAssumeIAMRole = $j('#eksAssumeIAMRole');
 
         this.$showAddImageDialogButton = $j('#showAddImageDialogButton');
         this.$addImageButton = $j('#kubeAddImageButton');
@@ -94,6 +96,8 @@ if(!BS.Kube.ProfileSettingsForm) BS.Kube.ProfileSettingsForm = OO.extend(BS.Plug
         this._renderImagesTable();
         this.$addImageButton.removeAttr('disabled');
         this._toggleAuth();
+        this._toggleEKSCredentials();
+        this._toggleEKSIAM();
 
         this._resetDataAndDialog();
 
@@ -125,6 +129,8 @@ if(!BS.Kube.ProfileSettingsForm) BS.Kube.ProfileSettingsForm = OO.extend(BS.Plug
         });
 
         this.$authStrategySelector.on('change', this._toggleAuth.bind(this));
+        this.$eksUseInstanceProfile.on('change', this._toggleEKSCredentials.bind(this));
+        this.$eksAssumeIAMRole.on('change', this._toggleEKSIAM.bind(this));
 
         this.$podSpecModeSelector.on('change', function(e, value) {
             if (arguments.length === 1) {
@@ -331,8 +337,24 @@ if(!BS.Kube.ProfileSettingsForm) BS.Kube.ProfileSettingsForm = OO.extend(BS.Plug
         var selectedStrategyId = this.$authStrategySelector.val();
         $j('.auth-ui').toggleClass('hidden', true);
         if(selectedStrategyId) {
-            $j('.' + selectedStrategyId).removeClass('hidden');
+            $j('.auth-ui.' + selectedStrategyId).removeClass('hidden');
         }
+        //workaround for TW-51797
+        BS.MultilineProperties.updateVisible();
+    },
+
+    _toggleEKSCredentials: function () {
+        var checked = this.$eksUseInstanceProfile.is(":checked");
+        $j('.eks.aws-credential').toggleClass('hidden', checked);
+
+        //workaround for TW-51797
+        BS.MultilineProperties.updateVisible();
+    },
+
+    _toggleEKSIAM: function () {
+        var checked = this.$eksAssumeIAMRole.is(":checked");
+        $j('.eks.aws-iam').toggleClass('hidden', !checked);
+
         //workaround for TW-51797
         BS.MultilineProperties.updateVisible();
     },


### PR DESCRIPTION
## What does this do?

Adds additional options for configuring AWS authentication for the EKS auth strategy including:
- Can now use the TeamCity server instance profile
- Can now assume a role using either the static credentials OR the instance profile

## Why?

The current restriction of only allowing static credentials is not ideal in an environment where credentials must be regularly rotated.

## Notes

<strike>I'm unable to build this locally so I can't confirm if my changes are valid. I'm not sure what I need to do to be able to build this project. I'll continue to mess about, but I'd appreciate any input you may have.</strike>