### PR TITLE
feat: custom resource deploy mode for XSmogVM agents in KCP

### DIFF
--- a/docs/BUILD-AND-INTEGRATION.md
+++ b/docs/BUILD-AND-INTEGRATION.md
@@ -1,0 +1,263 @@
+# Building the plugin and integrating XSmogVM agents with TeamCity
+
+This fork of `JetBrains/teamcity-kubernetes-plugin` adds a **custom resource deploy mode**
+that lets a TeamCity Kubernetes cloud profile provision build agents by creating
+**XSmogVM** Crossplane resources in a **KCP workspace** (instead of Pods in a regular
+cluster). Crossplane reconciles each XSmogVM into a KubeVirt VM whose golden image runs a
+TeamCity build agent that self-registers as an ephemeral cloud agent.
+
+Companion docs:
+
+- [DESIGN-xsmogvm-kcp.md](DESIGN-xsmogvm-kcp.md) — why the stock plugin can't do this and the design.
+- [PoC-oidc-kcp.md](PoC-oidc-kcp.md) — proving Keycloak `oidc` auth against the KCP workspace before anything else.
+
+---
+
+## 1. Building
+
+### Prerequisites
+
+- Docker (no local JDK/Maven needed), or JDK 17 + Maven 3.9 locally.
+- Network access to `download.jetbrains.com` and `packages.jetbrains.team` (the build
+  pulls TeamCity open-API artifacts and the `5.16.0-teamcity-patched` fabric8 client).
+
+### Containerized build (recommended)
+
+```bash
+cd teamcity-kubevirt-plugin
+docker run --rm \
+  -v "$PWD":/src \
+  -v kubevirt-plugin-m2:/root/.m2 \
+  -w /src \
+  maven:3.9-eclipse-temurin-17 \
+  mvn -B package -Dteamcity.version=2025.11
+```
+
+Notes:
+
+- **`-Dteamcity.version` is required**: the pom defaults to `LOCAL-SNAPSHOT`, which only
+  exists in JetBrains' internal dev environment. Use **2025.11** — the base commit tracks
+  upstream master, which needs `CanStartNewInstanceResult.ReasonType` (added in 2025.11;
+  2025.07 and older fail to compile). Don't use 2026.1: its published `server-api`/
+  `cloud-interface` artifacts are restructured stubs that this pom layout can't consume.
+- The named volume `kubevirt-plugin-m2` caches dependencies between builds.
+- Add `-DskipTests` to skip the TestNG suite once you trust a change.
+- Known: 4 upstream tests (`KubernetesCredentialsFactoryImplTest`,
+  `AvailableKubeConnectionsControllerTest`, `EKSAuthStrategyTest`,
+  `DefaultServiceAccountAuthStrategyTest`) fail outside JetBrains' environment with
+  `NoClassDefFoundError: jetbrains/buildServer/license/ReleaseDateHolder` — the published
+  test harness lacks internal license classes. Unrelated to this fork's changes; the
+  build still packages successfully.
+- The code targets Java 8 (`maven.compiler.release=8`); JDK 17 cross-compiles it fine.
+
+### Build output
+
+The deployable plugin package is the **server-side zip** produced by the root module:
+
+```
+target/teamcity-kubernetes-plugin.zip
+```
+
+(The exact name matches `teamcity-plugin.xml`'s plugin name; check `target/` after the build.)
+
+### Installing into TeamCity
+
+1. TeamCity UI → **Administration → Plugins → Upload plugin zip**, or copy the zip into
+   `<TeamCity Data Directory>/plugins/`.
+2. Restart the server (or use plugin reload if your version supports it).
+3. The stock "Kubernetes Support" bundled plugin must be **disabled** if its version
+   collides with this fork (both register cloud code `kube`). Administration → Plugins →
+   disable the bundled one.
+
+---
+
+## 2. What the new deploy mode does
+
+A cloud image configured with **“Use custom resource template (VM / KCP)”**:
+
+1. Generates an instance name from the **agent name prefix** (e.g. `winvm-3`).
+2. Takes your **custom resource manifest** (YAML), substitutes placeholders, stamps
+   `metadata.name` with the instance name and injects the TeamCity tracking labels
+   (`teamcity-agent`, `teamcity-server-uuid`, `teamcity-cloud-profile`, `teamcity-cloud-image`).
+3. `POST`s it to the API server / KCP workspace using the GVK **derived from the
+   manifest's `apiVersion`/`kind`** (plural derived from kind, or set explicitly).
+4. Discovers/synchronizes instances every 60 s by listing that GVK with the labels above
+   (`teamcity.kube.pods.monitoring.period` to tune).
+5. Marks the instance **RUNNING** when **the build agent registers on the server**
+   (primary signal — your golden image "connects to TeamCity and that marks it ready"),
+   or when the resource reports a Crossplane-style `Ready=True` condition.
+   A `Synced=False` condition is surfaced as the instance error in the cloud profile UI.
+6. On scale-down/idle-timeout, TeamCity **deletes the custom resource**; Crossplane
+   garbage-collects the VM. Ephemeral agents: every build (or idle period) ends with the
+   VM destroyed, the next demand creates a fresh one.
+
+### Placeholders available in the manifest
+
+| Placeholder | Value | Must end up as (in the VM) |
+|---|---|---|
+| `%instance.id%` | generated resource/instance name | env `TC_K8S_INSTANCE_NAME` |
+| `%agent.name%` | agent name prefix + instance id | agent `name` in `buildAgent.properties` |
+| `%server.url%` | TeamCity server URL | agent `serverUrl` |
+| `%server.uuid%` | TeamCity server UUID | env `TC_K8S_SERVER_UUID` |
+| `%profile.id%` | cloud profile id | env `TC_K8S_CLOUD_PROFILE_ID` |
+| `%image.id%` | cloud image id | env `TC_K8S_IMAGE_NAME` |
+
+---
+
+## 3. The agent bootstrap contract (golden image)
+
+TeamCity matches a registering agent to a cloud instance through **environment
+variables visible to the agent process**. The VM image must set, before the agent starts:
+
+```
+TC_K8S_SERVER_UUID      = %server.uuid%
+TC_K8S_CLOUD_PROFILE_ID = %profile.id%
+TC_K8S_IMAGE_NAME       = %image.id%
+TC_K8S_INSTANCE_NAME    = %instance.id%
+SERVER_URL              = %server.url%        (what the agent connects to)
+```
+
+On Windows, set them machine-wide before the agent service starts, e.g. in a
+cloud-init/sysprep step:
+
+```powershell
+[Environment]::SetEnvironmentVariable('TC_K8S_SERVER_UUID','%server.uuid%','Machine')
+[Environment]::SetEnvironmentVariable('TC_K8S_CLOUD_PROFILE_ID','%profile.id%','Machine')
+[Environment]::SetEnvironmentVariable('TC_K8S_IMAGE_NAME','%image.id%','Machine')
+[Environment]::SetEnvironmentVariable('TC_K8S_INSTANCE_NAME','%instance.id%','Machine')
+[Environment]::SetEnvironmentVariable('SERVER_URL','%server.url%','Machine')
+# point the preinstalled agent at the server and name it
+(Get-Content C:\BuildAgent\conf\buildAgent.properties) `
+  -replace '^serverUrl=.*','serverUrl=%server.url%' `
+  -replace '^name=.*','name=%agent.name%' |
+  Set-Content C:\BuildAgent\conf\buildAgent.properties
+Restart-Service TCBuildAgent
+```
+
+Alternatively, append the values as `env.TC_K8S_*=...` lines to
+`buildAgent.properties` — TeamCity treats those identically for matching.
+
+How the manifest delivers this is up to your XSmogVM spec — typically a cloud-init
+`userData`/sysprep field where you embed the placeholders.
+
+### Ephemeral behavior
+
+- Set the cloud profile's **terminate conditions** ("terminate instance: after first
+  build", or an idle timeout) — TeamCity then deletes the XSmogVM after each build,
+  giving you single-use VMs.
+- Agent authorization is automatic for cloud agents once the instance is matched.
+
+---
+
+## 4. TeamCity configuration walkthrough
+
+### 4.1 Keycloak / KCP auth (once)
+
+Follow [PoC-oidc-kcp.md](PoC-oidc-kcp.md): create the confidential Keycloak client, mint
+an **offline** refresh token (`scope=openid offline_access`), verify with `curl` that the
+resulting `id_token` can list resources in the workspace.
+
+### 4.2 Cloud profile
+
+Project **Settings → Cloud Profiles → Add profile → Kubernetes Agents**:
+
+| Field | Value |
+|---|---|
+| Kubernetes API server URL | the KCP **workspace** URL, e.g. `https://<kcp-host>/clusters/root:smog:bcn` |
+| CA certificate | the KCP CA (avoid disabling TLS verification) |
+| Namespace | leave **empty** for cluster-scoped XSmogVMs (the connection test then just verifies API reachability — this fork no longer requires a namespace); set it if your resources are namespaced claims |
+| Authentication strategy | **Open ID** (`client_id`, `client_secret`, `issuer_url` = `https://<kc>/realms/<realm>`, `refresh_token`) |
+
+Click **Test connection** — with an empty namespace it verifies reachability/auth (a 403
+on listing namespaces still counts as success, since KCP RBAC may only grant access to
+your CRs).
+
+### 4.3 Cloud image
+
+**Add image** in the profile:
+
+| Field | Value |
+|---|---|
+| Agent name prefix | e.g. `winvm` (required for this mode; also used as the resource name prefix) |
+| Pod specification | **Use custom resource template (VM / KCP)** |
+| Custom resource manifest | your XSmogVM YAML (below) |
+| Cluster-scoped resource | check for a Crossplane composite/XR (`XSmogVM`); uncheck for a namespaced claim |
+| Resource plural | `xsmogvms` (optional — derived from the kind if empty) |
+| Max instances / agent pool | as usual |
+
+Example manifest:
+
+```yaml
+apiVersion: smog.example.io/v1alpha1   # your real group/version
+kind: XSmogVM
+metadata:
+  labels:
+    smog.example.io/purpose: teamcity-agent
+spec:
+  image: windows-server-2022-tc-agent   # golden image with the TC agent preinstalled
+  cpu: 8
+  memoryGi: 16
+  userData: |
+    # consumed by cloud-init/sysprep inside the VM
+    serverUrl=%server.url%
+    agentName=%agent.name%
+    serverUuid=%server.uuid%
+    profileId=%profile.id%
+    imageId=%image.id%
+    instanceId=%instance.id%
+```
+
+`metadata.name` is set by the plugin — don't hardcode it. Labels you add are preserved;
+the plugin adds its tracking labels on top, and discovery re-reads the resource by those
+labels, so the composition must not strip labels from the XSmogVM itself.
+
+### 4.4 RBAC in the KCP workspace
+
+The identity behind the OIDC token needs, on the XSmogVM GVK (and `namespaces` get/list
+if you set a namespace):
+
+```
+verbs: get, list, create, delete
+```
+
+### 4.5 Verify end to end
+
+1. Test connection on the profile → success.
+2. Agents → Cloud tab → **Start** an instance of the image; an `xsmogvm` named
+   `<prefix>-1` should appear in the workspace (`kubectl --server <workspace-url> get xsmogvms`).
+3. The VM boots, the agent registers; the instance flips to Running on the cloud tab the
+   moment the agent connects (this fork marks it ready on agent registration).
+4. Run a build pinned to the image's agent pool; on completion/idle-timeout TeamCity
+   deletes the resource and Crossplane tears the VM down.
+
+---
+
+## 5. Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---|---|
+| Test connection: `invalid namespace` | You set a namespace that doesn't exist in the workspace. For cluster-scoped XSmogVMs, leave it empty. |
+| Test connection: 401 | OIDC trust broken — check issuer URL, client secret, refresh token freshness (use an offline token), KCP `--oidc-*` flags. |
+| Resource created but instance stuck "Starting" | The VM never registered an agent. Check VM console: env vars set? `serverUrl` reachable from the VM network? Server UUID/profile id mismatched (agent registers but isn't matched — see `teamcity-clouds.log`). |
+| Instance error `ReconcileError: ...` | Crossplane `Synced=False` — the composition failed; inspect the XSmogVM with `kubectl describe`. |
+| `405` / `404` creating the resource | Wrong plural (set **Resource plural** explicitly) or the API isn't bound into the workspace. |
+| Agent registers but a new instance starts for each build forever | Profile terminate conditions — that's the ephemeral design; tune idle timeout if you want reuse. |
+| Plugin doesn't load | Conflict with the bundled Kubernetes plugin — disable it. |
+
+Server logs: `teamcity-clouds.log` carries everything this plugin does (creation,
+discovery, agent-registered transitions, deletions).
+
+---
+
+## 6. Code map of the fork's changes
+
+| Area | Files |
+|---|---|
+| Generic CR connector ops | `connector/KubeApiConnector(.Impl)`, `connector/CustomResourceContext` |
+| Deploy mode | `podSpec/CustomResourceTemplateProvider` (registered in `BuildAgentPodTemplateProvidersImpl`) |
+| Instance lifecycle | `KubeCloudCustomResourceInstance`, CR branches in `KubeCloudClient` (start/terminate) and `KubeCloudImageImpl.populateInstances` |
+| Readiness on agent registration | `KubeBackgroundUpdaterImpl` (agentRegistered listener) |
+| KCP-friendly connection test | `KubeApiConnectorImpl.testConnection` (empty namespace ⇒ reachability/auth check) |
+| UI | `editProfile.jsp`, `kubeSettings.js` (manifest editor, cluster-scoped flag, plural override) |
+| Image params | `KubeParametersConstants`, `KubeCloudImageData`, `KubeCloudImage(.Impl)` |
+| Tests | `CustomResourceContextTest`, `CustomResourceTemplateProviderTest`, `KubeCloudCustomResourceInstanceTest` |

--- a/docs/DESIGN-xsmogvm-kcp.md
+++ b/docs/DESIGN-xsmogvm-kcp.md
@@ -1,0 +1,64 @@
+# TeamCity → KCP → XSmogVM cloud agents
+
+Fork of `JetBrains/teamcity-kubernetes-plugin` (Apache-2.0, base commit `6868bd6`).
+
+## Goal
+
+Run TeamCity cloud build agents as VMs, where:
+
+- the cloud connection targets a **KCP workspace** (not a normal kube-apiserver),
+- agents are provisioned by creating an **`XSmogVM`** Crossplane resource (not a raw
+  KubeVirt `VirtualMachineInstance`), which Crossplane reconciles into the actual
+  KubeVirt VM + networking on a physical cluster,
+- auth uses the plugin's existing **`oidc`** strategy against Keycloak (the federation
+  that already lets KCP trust Keycloak id_tokens).
+
+## Why the stock plugin can't do this
+
+The instance lifecycle is hardcoded to **Pods**:
+
+- `KubeApiConnector`: `Pod createPod(Pod)`, `deletePod(name)`, discovery via
+  `kubernetesClient.pods().withLabels(labels).list()`.
+- All deploy modes (`SimpleRunContainerProvider`, `CustomTemplatePodTemplateProvider`,
+  `DeploymentBuildAgentPodTemplateProvider`) return a `Pod`.
+
+Against **KCP this is meaningless** — KCP serves no pods/nodes. And an `XSmogVM` is a
+different GVK entirely. So this is "add a custom-resource lifecycle beside the Pod
+lifecycle", not "add a deploy mode".
+
+## Design (generic custom-resource deploy mode)
+
+1. **Dependency:** none new — use fabric8 `client.genericKubernetesResources(context)`
+   with a `ResourceDefinitionContext` built from the XSmogVM GVK. Avoids a
+   `kubevirt-client` dep and keeps it generic.
+2. **Connector:** generalize create/delete/get/list from `Pod` to
+   `GenericKubernetesResource` (new methods `createResource/deleteResource/listResources`
+   keyed by GVK + label selector), or add a parallel `XSmogVmApiConnector`.
+3. **New deploy mode:** `CustomResourceTemplateProvider` — takes user-supplied YAML
+   (the `XSmogVM` manifest), injects TeamCity instance tags as labels + injects agent
+   bootstrap config into the VM spec (see #5), and stamps the instance id.
+4. **Readiness:** configurable status path — for Crossplane, poll
+   `status.conditions[type=Ready].status == "True"` instead of pod phase `Running`.
+5. **Agent bootstrap glue:** the VM image runs a TeamCity agent that self-registers with
+   the same instance tags the plugin matches on (`KubeTeamCityLabels` /
+   `KubeContainerEnvironment`: server URL, instance name, image id, auth token). For a VM
+   this is delivered via the `XSmogVM` spec (cloud-init / sysprep), reusing the existing
+   golden-image flow.
+6. **KCP awareness:**
+   - API URL is a workspace URL: `https://<kcp>/clusters/root:smog:<ws>`.
+   - The connection "test"/discovery must NOT list pods. List namespaces or the XSmogVM
+     CRs in the workspace instead — relax `KubeApiConnectorImpl` accordingly.
+
+## Sequencing
+
+1. **Auth PoC** (no fork build needed) — verify `oidc` + Keycloak authenticates to the
+   KCP workspace. See `PoC-oidc-kcp.md`.
+2. **Static self-registering VM** — `XSmogVM` whose image self-registers as a TC agent;
+   working agents today, and it nails down the bootstrap contract for #5.
+3. **Custom-resource deploy mode** — the connector generalization + provider + UI so
+   TeamCity manages XSmogVM lifecycle (scale up / tear down).
+
+## Build note
+
+No JDK/Maven in the current dev env. Build in a JDK 17 + Maven container (or in TeamCity).
+Base toolchain per upstream `pom.xml`.

--- a/docs/PoC-oidc-kcp.md
+++ b/docs/PoC-oidc-kcp.md
@@ -1,0 +1,80 @@
+# Auth PoC: TeamCity `oidc` strategy → Keycloak → KCP workspace
+
+Goal: prove the **built-in** `oidc` auth strategy authenticates a TeamCity Kubernetes
+cloud profile to a **KCP workspace**, before writing any VM code. No fork build required —
+the `oidc` ("Open ID") strategy already ships in the installed plugin.
+
+## How the strategy behaves (read from source)
+
+`OIDCAuthStrategy.kt` + `RefreshableStrategy.kt`:
+
+- Inputs: `client_id`, `client_secret` (secure), `issuer_url`, `refresh_token` (secure).
+- On use: resolves `<issuer>/.well-known/openid-configuration` (tries an Azure-style
+  `v2.0/...` first, then falls back to the plain path — the fallback is what Keycloak
+  uses), reads `token_endpoint`, then does a **`grant_type=refresh_token`** POST with the
+  client creds as HTTP Basic, and uses the returned **`id_token`** as the cluster bearer
+  token. Caches by `expires_in`, refreshes on expiry.
+
+Implications:
+- The refresh response must contain `id_token` → the original token must have been issued
+  with scope `openid`.
+- For a long-lived CI credential, mint an **offline** refresh token (`scope=openid
+  offline_access`) so it survives SSO session idle/max. (See token-freshness gotchas in
+  the federated-JWT notes.)
+
+## Keycloak setup
+
+1. Confidential client, e.g. `teamcity-kcp`: client authentication ON (note the secret),
+   standard flow enabled.
+2. Ensure the client/realm issues an `id_token` whose `iss` and `aud` match what KCP is
+   configured to trust (KCP `--oidc-issuer-url` / `--oidc-client-id`).
+3. Mint the initial offline refresh token once (auth-code or password grant), e.g.:
+
+   ```bash
+   curl -s -X POST "https://<kc>/realms/<realm>/protocol/openid-connect/token" \
+     -d grant_type=password -d client_id=teamcity-kcp \
+     -d client_secret=<secret> -d username=<svc-user> -d password=<pw> \
+     -d 'scope=openid offline_access' | jq -r .refresh_token
+   ```
+
+   Capture `refresh_token` — that is the value for the strategy's "Refresh token" field.
+
+## TeamCity cloud profile
+
+Project Settings → Cloud Profiles → add **Kubernetes**:
+
+- **Kubernetes API server URL** = the KCP **workspace** URL, e.g.
+  `https://<kcp-host>/clusters/root:smog:bcn`.
+- **Authentication strategy** = **Open ID**.
+- Fill `client_id`, `client_secret`, `issuer_url` (`https://<kc>/realms/<realm>`),
+  `refresh_token`.
+- Provide the KCP CA cert (prefer over disabling TLS verify).
+- Namespace = the workspace namespace where `SmogVM` claims live (if namespaced).
+
+## Verifying auth WITHOUT pods (the KCP twist)
+
+KCP serves no pods, so the stock "test connection" (which lists pods) will fail even when
+auth is fine. Isolate auth from the plugin's pod assumption:
+
+1. Get an id_token the same way the strategy does, then hit the workspace directly:
+
+   ```bash
+   ID_TOKEN=$(curl -s -X POST "https://<kc>/realms/<realm>/protocol/openid-connect/token" \
+     -u teamcity-kcp:<secret> \
+     -d grant_type=refresh_token -d refresh_token="<refresh_token>" | jq -r .id_token)
+
+   curl -sk -H "Authorization: Bearer $ID_TOKEN" \
+     "https://<kcp-host>/clusters/root:smog:bcn/api/v1/namespaces" | jq '.items[].metadata.name'
+   # or list your CRs:
+   curl -sk -H "Authorization: Bearer $ID_TOKEN" \
+     "https://<kcp-host>/clusters/root:smog:bcn/apis/<group>/<version>/xsmogvms"
+   ```
+
+2. 200 + a JSON list → Keycloak→KCP trust + RBAC are good; auth is proven.
+   401/403 → fix issuer/aud trust or RBAC binding for the token's user/groups.
+
+## Outcome
+
+If step 2 returns data, the `oidc` strategy will authenticate the cloud profile. The
+remaining work is the VM lifecycle (see `DESIGN-xsmogvm-kcp.md`) — including relaxing the
+connection test so it does not assume pods.

--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeBackgroundUpdaterImpl.java
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeBackgroundUpdaterImpl.java
@@ -4,12 +4,18 @@ package jetbrains.buildServer.clouds.kubernetes;
 import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.clouds.CloudErrorInfo;
 import jetbrains.buildServer.clouds.CloudImage;
+import jetbrains.buildServer.clouds.CloudInstance;
+import jetbrains.buildServer.clouds.InstanceStatus;
+import jetbrains.buildServer.serverSide.BuildServerAdapter;
+import jetbrains.buildServer.serverSide.BuildServerListener;
+import jetbrains.buildServer.serverSide.SBuildAgent;
 import jetbrains.buildServer.serverSide.TeamCityProperties;
 import jetbrains.buildServer.serverSide.executors.ExecutorServices;
+import jetbrains.buildServer.util.EventDispatcher;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -19,11 +25,39 @@ public class KubeBackgroundUpdaterImpl implements KubeBackgroundUpdater {
     private static final Logger LOG = Logger.getInstance(KubeBackgroundUpdaterImpl.class.getName());
     private static final String KUBE_POD_MONITORING_PERIOD = "teamcity.kube.pods.monitoring.period";
 
-    private final Collection<KubeCloudClient> myRegisteredClients = new ArrayList<>();
+    private final Collection<KubeCloudClient> myRegisteredClients = new CopyOnWriteArrayList<>();
 
-    public KubeBackgroundUpdaterImpl(@NotNull ExecutorServices executorServices) {
+    public KubeBackgroundUpdaterImpl(@NotNull ExecutorServices executorServices,
+                                     @NotNull EventDispatcher<BuildServerListener> eventDispatcher) {
         long delay = TeamCityProperties.getLong(KUBE_POD_MONITORING_PERIOD, 60);
         executorServices.getNormalExecutorService().scheduleWithFixedDelay(this::populateInstances, delay, delay, TimeUnit.SECONDS);
+        // Custom resources (VMs) have no universal status contract; the most reliable readiness
+        // signal is the baked-in build agent actually registering on the server.
+        eventDispatcher.addListener(new BuildServerAdapter() {
+            @Override
+            public void agentRegistered(@NotNull SBuildAgent agent, long currentlyRunningBuildId) {
+                try {
+                    markInstanceRunning(agent);
+                } catch (Exception ex) {
+                    LOG.warnAndDebugDetails("Failed to update cloud instance status for registered agent " + agent.getName(), ex);
+                }
+            }
+        });
+    }
+
+    private void markInstanceRunning(@NotNull SBuildAgent agent) {
+        for (KubeCloudClient client : myRegisteredClients) {
+            final CloudInstance instance = client.findInstanceByAgent(agent);
+            if (instance instanceof KubeCloudInstance) {
+                final KubeCloudInstance kubeInstance = (KubeCloudInstance)instance;
+                final InstanceStatus status = kubeInstance.getStatus();
+                if (status == InstanceStatus.SCHEDULED_TO_START || status == InstanceStatus.STARTING) {
+                    LOG.info(String.format("Agent '%s' registered - marking cloud instance '%s' as running", agent.getName(), kubeInstance.getName()));
+                    kubeInstance.setStatus(InstanceStatus.RUNNING);
+                }
+                return;
+            }
+        }
     }
 
     @Override

--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeCloudClient.java
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeCloudClient.java
@@ -3,6 +3,7 @@ package jetbrains.buildServer.clouds.kubernetes;
 
 import com.google.common.collect.Maps;
 import com.intellij.openapi.diagnostic.Logger;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -14,9 +15,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import jetbrains.buildServer.agent.Constants;
 import jetbrains.buildServer.clouds.*;
+import jetbrains.buildServer.clouds.kubernetes.connector.CustomResourceContext;
 import jetbrains.buildServer.clouds.kubernetes.connector.KubeApiConnector;
 import jetbrains.buildServer.clouds.kubernetes.podSpec.BuildAgentPodTemplateProvider;
 import jetbrains.buildServer.clouds.kubernetes.podSpec.BuildAgentPodTemplateProviders;
+import jetbrains.buildServer.clouds.kubernetes.podSpec.CustomResourceTemplateProvider;
 import jetbrains.buildServer.serverSide.AgentDescription;
 import jetbrains.buildServer.serverSide.TeamCityProperties;
 import jetbrains.buildServer.util.FileUtil;
@@ -88,6 +91,9 @@ public class KubeCloudClient implements CloudClientEx {
         final KubeCloudImage kubeCloudImage = (KubeCloudImage)cloudImage;
         BuildAgentPodTemplateProvider podTemplateProvider = myPodTemplateProviders.get(kubeCloudImage.getPodSpecMode());
         final String instanceName = myNameGenerator.generateNewVmName(kubeCloudImage);
+        if (podTemplateProvider instanceof CustomResourceTemplateProvider) {
+            return startNewCustomResourceInstance((CustomResourceTemplateProvider)podTemplateProvider, instanceName, cloudInstanceUserData, kubeCloudImage);
+        }
         final Pod podTemplate = podTemplateProvider.getPodTemplate(instanceName, cloudInstanceUserData, kubeCloudImage, myApiConnector);
         final PersistentVolumeClaim pvc = podTemplateProvider.getPVC(instanceName, kubeCloudImage);
         if (pvc != null){
@@ -120,6 +126,31 @@ public class KubeCloudClient implements CloudClientEx {
         return instance;
     }
 
+    @NotNull
+    private CloudInstance startNewCustomResourceInstance(@NotNull CustomResourceTemplateProvider provider,
+                                                         @NotNull String instanceName,
+                                                         @NotNull CloudInstanceUserData cloudInstanceUserData,
+                                                         @NotNull KubeCloudImage kubeCloudImage) {
+        final GenericKubernetesResource resourceTemplate = provider.getResourceTemplate(instanceName, cloudInstanceUserData, kubeCloudImage, myApiConnector);
+        final CustomResourceContext resourceContext = kubeCloudImage.getCustomResourceContext();
+        final KubeCloudInstance instance = new KubeCloudCustomResourceInstance(kubeCloudImage, resourceTemplate);
+        kubeCloudImage.addStartedInstance(instance);
+        // Once instance added to the kubeCloudImage, we could unlock name from name generator.
+        myNameGenerator.vmNameSaved(instanceName);
+        myExecutorService.submit(() -> {
+            try {
+                final GenericKubernetesResource newResource = myApiConnector.createCustomResource(resourceContext, resourceTemplate);
+                instance.updateState(newResource);
+            } catch (KubeCloudException | KubernetesClientException ex) {
+                LOG.warnAndDebugDetails("An error occurred while starting new custom resource instance", ex);
+                instance.setStatus(InstanceStatus.ERROR);
+                instance.setError(new CloudErrorInfo("Instance cannot be started", ex.getMessage(), ex));
+                throw ex;
+            }
+        });
+        return instance;
+    }
+
     @Override
     public void restartInstance(@NotNull CloudInstance cloudInstance) {
         throw new UnsupportedOperationException("Restart not implemented");
@@ -134,6 +165,17 @@ public class KubeCloudClient implements CloudClientEx {
             kubeCloudInstance.setStatus(InstanceStatus.STOPPING);
             try{
                 int failedDeleteAttempts = 0;
+                if (kubeCloudInstance instanceof KubeCloudCustomResourceInstance){
+                    final CustomResourceContext resourceContext = kubeCloudInstance.getImage().getCustomResourceContext();
+                    while (!myApiConnector.deleteCustomResource(resourceContext, kubeCloudInstance.getName())){
+                        failedDeleteAttempts++;
+                        if(failedDeleteAttempts == 3) throw new KubeCloudException("Failed to delete custom resource " + kubeCloudInstance.getName());
+                    }
+                    kubeCloudInstance.setError(null);
+                    kubeCloudInstance.setStatus(InstanceStatus.STOPPED);
+                    kubeCloudInstance.getImage().populateInstances();
+                    return;
+                }
                 final String pvcName = kubeCloudInstance.getPVCName();
                 while (!myApiConnector.deletePod(kubeCloudInstance.getName(), gracePeriod)){
                     failedDeleteAttempts++;

--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeCloudCustomResourceInstance.java
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeCloudCustomResourceInstance.java
@@ -1,0 +1,173 @@
+
+package jetbrains.buildServer.clouds.kubernetes;
+
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import jetbrains.buildServer.clouds.CloudErrorInfo;
+import jetbrains.buildServer.clouds.InstanceStatus;
+import jetbrains.buildServer.serverSide.AgentDescription;
+import jetbrains.buildServer.util.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static jetbrains.buildServer.clouds.kubernetes.KubeContainerEnvironment.INSTANCE_NAME;
+
+/**
+ * A cloud instance backed by an arbitrary custom resource (e.g. an XSmogVM Crossplane composite
+ * reconciled into a KubeVirt VM). Unlike pods, custom resources have no universal status contract,
+ * so the instance becomes RUNNING when either:
+ * <ul>
+ *   <li>the build agent baked into the VM image registers on the TeamCity server
+ *       (see {@link KubeBackgroundUpdaterImpl}), or</li>
+ *   <li>the resource reports the Crossplane-style condition {@code Ready=True}.</li>
+ * </ul>
+ * A {@code Synced=False} condition (Crossplane reconcile failure) is surfaced as the instance error.
+ */
+public class KubeCloudCustomResourceInstance implements KubeCloudInstance {
+    static final String READY_CONDITION = "Ready";
+    static final String SYNCED_CONDITION = "Synced";
+
+    private final KubeCloudImage myKubeCloudImage;
+    @NotNull private volatile GenericKubernetesResource myResource;
+    private volatile InstanceStatus myInstanceStatus = InstanceStatus.SCHEDULED_TO_START;
+
+    private volatile CloudErrorInfo myCurrentError;
+    private final Date myCreationTime;
+    private final SimpleDateFormat myCreationTimestampFormat;
+
+    public KubeCloudCustomResourceInstance(@NotNull KubeCloudImage kubeCloudImage, @NotNull GenericKubernetesResource resource) {
+        myKubeCloudImage = kubeCloudImage;
+        myResource = resource;
+        myCreationTime = new Date();
+        myCreationTimestampFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        myCreationTimestampFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    @NotNull
+    @Override
+    public String getInstanceId() {
+        return myResource.getMetadata().getName();
+    }
+
+    @NotNull
+    @Override
+    public String getName() {
+        return myResource.getMetadata().getName();
+    }
+
+    @NotNull
+    @Override
+    public String getImageId() {
+        return myKubeCloudImage.getId();
+    }
+
+    @NotNull
+    @Override
+    public KubeCloudImage getImage() {
+        return myKubeCloudImage;
+    }
+
+    @Override
+    public void setStatus(final InstanceStatus status) {
+        myInstanceStatus = status;
+    }
+
+    @NotNull
+    @Override
+    public Date getStartedTime() {
+        final String creationTimestamp = myResource.getMetadata().getCreationTimestamp();
+        if (!StringUtil.isEmpty(creationTimestamp)) {
+            try {
+                return myCreationTimestampFormat.parse(creationTimestamp);
+            } catch (ParseException ignored) {
+            }
+        }
+        return myCreationTime;
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkIdentity() {
+        return null;
+    }
+
+    @NotNull
+    @Override
+    public InstanceStatus getStatus() {
+        return myInstanceStatus;
+    }
+
+    @Nullable
+    @Override
+    public CloudErrorInfo getErrorInfo() {
+        return myCurrentError;
+    }
+
+    @Override
+    public boolean containsAgent(@NotNull AgentDescription agentDescription) {
+        final Map<String, String> buildParams = agentDescription.getBuildParameters();
+        return getName().equals(buildParams.get("env." + INSTANCE_NAME));
+    }
+
+    @Override
+    public void updateState(@NotNull HasMetadata resource) {
+        if (!(resource instanceof GenericKubernetesResource)) {
+            throw new KubeCloudException("Custom resource instance '" + getName() + "' cannot be updated from a " + resource.getKind());
+        }
+        myResource = (GenericKubernetesResource)resource;
+
+        final Map<String, String> syncedCondition = findCondition(myResource, SYNCED_CONDITION);
+        if (syncedCondition != null && "False".equalsIgnoreCase(syncedCondition.get("status"))) {
+            final String reason = syncedCondition.get("reason");
+            final String message = syncedCondition.get("message");
+            myCurrentError = new CloudErrorInfo(StringUtil.notEmpty(reason, "ReconcileError"), StringUtil.emptyIfNull(message));
+        } else {
+            myCurrentError = null;
+        }
+
+        if (!getStatus().isCanTerminate()) { // don't update status if instance is going to be terminated
+            return;
+        }
+        final Map<String, String> readyCondition = findCondition(myResource, READY_CONDITION);
+        if (readyCondition != null && "True".equalsIgnoreCase(readyCondition.get("status"))) {
+            setStatus(InstanceStatus.RUNNING);
+        } else if (myInstanceStatus == InstanceStatus.SCHEDULED_TO_START) {
+            // the resource exists on the API server but the VM is not ready yet
+            setStatus(InstanceStatus.STARTING);
+        }
+    }
+
+    @Nullable
+    @SuppressWarnings("unchecked")
+    private static Map<String, String> findCondition(@NotNull GenericKubernetesResource resource, @NotNull String conditionType) {
+        final Map<String, Object> additionalProperties = resource.getAdditionalProperties();
+        if (additionalProperties == null) return null;
+        final Object status = additionalProperties.get("status");
+        if (!(status instanceof Map)) return null;
+        final Object conditions = ((Map<String, Object>)status).get("conditions");
+        if (!(conditions instanceof List)) return null;
+        for (Object condition : (List<Object>)conditions) {
+            if (condition instanceof Map && conditionType.equals(((Map<String, Object>)condition).get("type"))) {
+                return (Map<String, String>)(Map<?, ?>)condition;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void setError(@Nullable final CloudErrorInfo errorInfo) {
+        myCurrentError = errorInfo;
+    }
+
+    @Override
+    @Nullable
+    public String getPVCName() {
+        return null;
+    }
+}

--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeCloudImage.java
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeCloudImage.java
@@ -3,6 +3,7 @@ package jetbrains.buildServer.clouds.kubernetes;
 
 import jetbrains.buildServer.clouds.CloudErrorInfo;
 import jetbrains.buildServer.clouds.CloudImage;
+import jetbrains.buildServer.clouds.kubernetes.connector.CustomResourceContext;
 import jetbrains.buildServer.clouds.kubernetes.connector.ImagePullPolicy;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -35,6 +36,24 @@ public interface KubeCloudImage extends CloudImage {
 
     @Nullable
     String getPVCTemplate();
+
+    /**
+     * Raw YAML manifest of the custom resource (e.g. XSmogVM) for the custom-resource deploy mode.
+     */
+    @Nullable
+    String getCustomResourceTemplate();
+
+    boolean isCustomResourceClusterScoped();
+
+    @Nullable
+    String getCustomResourcePlural();
+
+    /**
+     * Resource type derived from {@link #getCustomResourceTemplate()}, or null when this image
+     * does not use the custom-resource deploy mode.
+     */
+    @Nullable
+    CustomResourceContext getCustomResourceContext();
 
     @Nullable
     String getSourceDeploymentName();

--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeCloudImageData.java
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeCloudImageData.java
@@ -54,6 +54,18 @@ public class KubeCloudImageData {
         return myRawImageData.getParameter(KubeParametersConstants.CUSTOM_POD_TEMPLATE);
     }
 
+    public String getCustomResourceTemplateContent() {
+        return myRawImageData.getParameter(KubeParametersConstants.CUSTOM_RESOURCE_TEMPLATE);
+    }
+
+    public boolean isCustomResourceClusterScoped() {
+        return Boolean.parseBoolean(myRawImageData.getParameter(KubeParametersConstants.CUSTOM_RESOURCE_CLUSTER_SCOPED));
+    }
+
+    public String getCustomResourcePlural() {
+        return myRawImageData.getParameter(KubeParametersConstants.CUSTOM_RESOURCE_PLURAL);
+    }
+
     public String getDeploymentName() {
         return myRawImageData.getParameter(KubeParametersConstants.SOURCE_DEPLOYMENT);
     }

--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeCloudImageImpl.java
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeCloudImageImpl.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
 import com.intellij.openapi.diagnostic.Logger;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import java.io.IOException;
@@ -17,8 +18,10 @@ import java.util.stream.Collectors;
 import jetbrains.buildServer.clouds.CloudErrorInfo;
 import jetbrains.buildServer.clouds.CloudInstance;
 import jetbrains.buildServer.clouds.InstanceStatus;
+import jetbrains.buildServer.clouds.kubernetes.connector.CustomResourceContext;
 import jetbrains.buildServer.clouds.kubernetes.connector.ImagePullPolicy;
 import jetbrains.buildServer.clouds.kubernetes.connector.KubeApiConnector;
+import jetbrains.buildServer.clouds.kubernetes.podSpec.CustomResourceTemplateProvider;
 import jetbrains.buildServer.util.CollectionsUtil;
 import jetbrains.buildServer.util.ExceptionUtil;
 import jetbrains.buildServer.util.StringUtil;
@@ -37,6 +40,7 @@ public class KubeCloudImageImpl implements KubeCloudImage {
 
     private final ConcurrentMap<String, KubeCloudInstance> myIdToInstanceMap = new ConcurrentHashMap<>();
     private CloudErrorInfo myCurrentError;
+    private volatile CustomResourceContext myCustomResourceContext;
 
     KubeCloudImageImpl(@NotNull final KubeCloudImageData kubeCloudImageData,
                        @NotNull final KubeApiConnector apiConnector) {
@@ -103,6 +107,45 @@ public class KubeCloudImageImpl implements KubeCloudImage {
     @Override
     public String getPVCTemplate() {
         return myPVCTemplate;
+    }
+
+    @Nullable
+    @Override
+    public String getCustomResourceTemplate() {
+        return myImageData.getCustomResourceTemplateContent();
+    }
+
+    @Override
+    public boolean isCustomResourceClusterScoped() {
+        return myImageData.isCustomResourceClusterScoped();
+    }
+
+    @Nullable
+    @Override
+    public String getCustomResourcePlural() {
+        return myImageData.getCustomResourcePlural();
+    }
+
+    @Nullable
+    @Override
+    public CustomResourceContext getCustomResourceContext() {
+        if (!isCustomResourceImage()) {
+            return null;
+        }
+        CustomResourceContext context = myCustomResourceContext;
+        if (context == null) {
+            final String template = getCustomResourceTemplate();
+            if (StringUtil.isEmpty(template)) {
+                throw new KubeCloudException("Custom resource template is not specified for image " + getId());
+            }
+            context = CustomResourceContext.fromTemplate(template, isCustomResourceClusterScoped(), getCustomResourcePlural());
+            myCustomResourceContext = context;
+        }
+        return context;
+    }
+
+    private boolean isCustomResourceImage() {
+        return CustomResourceTemplateProvider.ID.equals(getPodSpecMode());
     }
 
     @Nullable
@@ -213,6 +256,10 @@ public class KubeCloudImageImpl implements KubeCloudImage {
     //TODO: synchronize access to myIdToInstanceMap
     //TODO: filter pods more carefully using all setted labels
     public void populateInstances(){
+        if (isCustomResourceImage()){
+            populateCustomResourceInstances();
+            return;
+        }
         try{
             final Collection<Pod> pods = myApiConnector.listPods(CollectionsUtil.asMap(
               KubeTeamCityLabels.TEAMCITY_CLOUD_IMAGE, myImageData.getId(),
@@ -262,6 +309,70 @@ public class KubeCloudImageImpl implements KubeCloudImage {
                 newPods.forEach(pod->{
                     final String podName = pod.getMetadata().getName();
                     myIdToInstanceMap.putIfAbsent(podName, new KubeCloudInstanceImpl(this, pod));
+                });
+            }
+            myCurrentError = null;
+        } catch (KubernetesClientException ex){
+            myCurrentError = new CloudErrorInfo("Failed populate instances", ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    private void populateCustomResourceInstances(){
+        try{
+            final Collection<GenericKubernetesResource> resources = myApiConnector.listCustomResources(
+              getCustomResourceContext(),
+              CollectionsUtil.asMap(
+                KubeTeamCityLabels.TEAMCITY_CLOUD_IMAGE, myImageData.getId(),
+                KubeTeamCityLabels.TEAMCITY_CLOUD_PROFILE, myImageData.getProfileId()
+              ));
+            final Set<String> keys = new HashSet<>(myIdToInstanceMap.keySet());
+            final List<GenericKubernetesResource> newResources = new ArrayList<>();
+            for (GenericKubernetesResource resource : resources){
+                if (resource.getMetadata() == null){
+                    LOG.debug("Found custom resource without metadata...");
+                    continue;
+                }
+                final String resourceName = resource.getMetadata().getName();
+                if (keys.remove(resourceName)){
+                    LOG.debug(String.format("Found known custom resource '%s'", resourceName));
+                    final KubeCloudInstance instance = myIdToInstanceMap.get(resourceName);
+                    if (instance == null){
+                        LOG.warn(String.format("Instance '%s' was removed?!", resourceName));
+                        continue;
+                    }
+                    instance.updateState(resource);
+                } else {
+                    LOG.debug(String.format("Found new custom resource '%s'", resourceName));
+                    newResources.add(resource);
+                }
+            }
+            keys.removeIf(instanceId->{
+                KubeCloudInstance instance = myIdToInstanceMap.get(instanceId);
+                return instance != null && instance.getStatus() == InstanceStatus.SCHEDULED_TO_START;
+            });
+            if (keys.size() > 0) {
+                LOG.info(String.format("The following %d custom %s %s deleted: %s",
+                                       keys.size(), StringUtil.pluralize("resource", keys.size()),
+                                       keys.size() == 1 ? "was" : "were",
+                                       String.join(", ", keys))
+                );
+                keys.forEach(myIdToInstanceMap::remove);
+            }
+            if (newResources.size() > 0){
+                final List<String> resourceNames = newResources.stream().map(resource -> resource.getMetadata().getName()).collect(Collectors.toList());
+                LOG.info(String.format(
+                  "Found %d new custom %s: %s",
+                  newResources.size(),
+                  StringUtil.pluralize("resource", newResources.size()),
+                  String.join(", ", resourceNames)
+                ));
+                newResources.forEach(resource->{
+                    final String resourceName = resource.getMetadata().getName();
+                    final KubeCloudInstance instance = new KubeCloudCustomResourceInstance(this, resource);
+                    if (myIdToInstanceMap.putIfAbsent(resourceName, instance) == null) {
+                        instance.updateState(resource);
+                    }
                 });
             }
             myCurrentError = null;

--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeCloudInstance.java
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeCloudInstance.java
@@ -1,7 +1,7 @@
 
 package jetbrains.buildServer.clouds.kubernetes;
 
-import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import jetbrains.buildServer.clouds.CloudErrorInfo;
 import jetbrains.buildServer.clouds.CloudInstance;
 import jetbrains.buildServer.clouds.InstanceStatus;
@@ -18,7 +18,11 @@ public interface KubeCloudInstance extends CloudInstance {
 
     void setStatus(final InstanceStatus status);
 
-    void updateState(Pod pod);
+    /**
+     * Updates the instance from the actual state of its backing resource
+     * (a Pod for pod-based deploy modes, a custom resource for the custom-resource mode).
+     */
+    void updateState(HasMetadata resource);
 
     void setError(@Nullable CloudErrorInfo errorInfo);
 

--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeCloudInstanceImpl.java
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeCloudInstanceImpl.java
@@ -1,6 +1,7 @@
 
 package jetbrains.buildServer.clouds.kubernetes;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodCondition;
 import io.fabric8.kubernetes.api.model.PodStatus;
@@ -124,7 +125,11 @@ public class KubeCloudInstanceImpl implements KubeCloudInstance {
         return getName().equals(buildParams.get("env."+INSTANCE_NAME));
     }
 
-    public void updateState(@NotNull Pod actualPod){
+    public void updateState(@NotNull HasMetadata resource){
+        if (!(resource instanceof Pod)) {
+            throw new KubeCloudException("Pod-based instance '" + getName() + "' cannot be updated from a " + resource.getKind());
+        }
+        final Pod actualPod = (Pod)resource;
         myPod = actualPod;
         InstanceStatus podStatus = KubeUtils.mapPodPhase(actualPod.getStatus());
         myCurrentError = KubeUtils.getErrorMessage(myPod.getStatus());

--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeParametersConstants.java
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/KubeParametersConstants.java
@@ -34,6 +34,9 @@ public class KubeParametersConstants {
     public static final String OIDC_REFRESH_TOKEN = "oidcRefreshToken";
     public static final String OIDC_ISSUER_URL = "idpIssuerUrl";
     public static final String CUSTOM_POD_TEMPLATE = "customPodTemplate";
+    public static final String CUSTOM_RESOURCE_TEMPLATE = "customResourceTemplate";
+    public static final String CUSTOM_RESOURCE_CLUSTER_SCOPED = "customResourceClusterScoped";
+    public static final String CUSTOM_RESOURCE_PLURAL = "customResourcePlural";
     public static final String SOURCE_DEPLOYMENT = "sourceDeployment";
     public static final String AGENT_NAME_PREFIX = "agentNamePrefix";
     public static final String KUBECONFIG_CONTEXT = "kubeconfigContext";
@@ -157,6 +160,18 @@ public class KubeParametersConstants {
 
     public String getCustomPodTemplate() {
         return CUSTOM_POD_TEMPLATE;
+    }
+
+    public String getCustomResourceTemplate() {
+        return CUSTOM_RESOURCE_TEMPLATE;
+    }
+
+    public String getCustomResourceClusterScoped() {
+        return CUSTOM_RESOURCE_CLUSTER_SCOPED;
+    }
+
+    public String getCustomResourcePlural() {
+        return CUSTOM_RESOURCE_PLURAL;
     }
 
     public String getMaxInstances() {

--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/connector/CustomResourceContext.java
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/connector/CustomResourceContext.java
@@ -1,0 +1,139 @@
+
+package jetbrains.buildServer.clouds.kubernetes.connector;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext;
+import java.io.IOException;
+import java.util.Objects;
+import jetbrains.buildServer.clouds.kubernetes.KubeCloudException;
+import jetbrains.buildServer.util.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Identifies a custom resource type (group/version/kind/plural + scope) so the
+ * connector can address arbitrary custom resources (e.g. an XSmogVM Crossplane
+ * composite in a KCP workspace) without compile-time model classes.
+ */
+public class CustomResourceContext {
+    @NotNull private final String myGroup;
+    @NotNull private final String myVersion;
+    @NotNull private final String myKind;
+    @NotNull private final String myPlural;
+    private final boolean myClusterScoped;
+
+    public CustomResourceContext(@NotNull String group,
+                                 @NotNull String version,
+                                 @NotNull String kind,
+                                 @Nullable String plural,
+                                 boolean clusterScoped) {
+        myGroup = group;
+        myVersion = version;
+        myKind = kind;
+        myPlural = StringUtil.isEmptyOrSpaces(plural) ? defaultPlural(kind) : plural.trim().toLowerCase();
+        myClusterScoped = clusterScoped;
+    }
+
+    /**
+     * Derives the resource type from a YAML manifest's apiVersion/kind fields.
+     */
+    @NotNull
+    public static CustomResourceContext fromTemplate(@NotNull String templateYaml,
+                                                     boolean clusterScoped,
+                                                     @Nullable String pluralOverride) {
+        final JsonNode root;
+        try {
+            root = new ObjectMapper(new YAMLFactory()).readTree(templateYaml);
+        } catch (IOException e) {
+            throw new KubeCloudException("Custom resource template is not valid YAML: " + e.getMessage(), e);
+        }
+        if (root == null || root.get("apiVersion") == null || root.get("kind") == null) {
+            throw new KubeCloudException("Custom resource template must specify both 'apiVersion' and 'kind'");
+        }
+        final String apiVersion = root.get("apiVersion").asText();
+        final String kind = root.get("kind").asText();
+        final int slash = apiVersion.indexOf('/');
+        final String group = slash < 0 ? "" : apiVersion.substring(0, slash);
+        final String version = slash < 0 ? apiVersion : apiVersion.substring(slash + 1);
+        if (StringUtil.isEmptyOrSpaces(version) || StringUtil.isEmptyOrSpaces(kind)) {
+            throw new KubeCloudException("Custom resource template has empty 'apiVersion' or 'kind'");
+        }
+        return new CustomResourceContext(group, version, kind, pluralOverride, clusterScoped);
+    }
+
+    @NotNull
+    private static String defaultPlural(@NotNull String kind) {
+        final String lower = kind.toLowerCase();
+        if (lower.endsWith("s") || lower.endsWith("x") || lower.endsWith("z") || lower.endsWith("ch") || lower.endsWith("sh")) {
+            return lower + "es";
+        }
+        if (lower.endsWith("y") && lower.length() > 1 && "aeiou".indexOf(lower.charAt(lower.length() - 2)) < 0) {
+            return lower.substring(0, lower.length() - 1) + "ies";
+        }
+        return lower + "s";
+    }
+
+    @NotNull
+    public ResourceDefinitionContext toResourceDefinitionContext() {
+        return new ResourceDefinitionContext.Builder()
+          .withGroup(StringUtil.isEmpty(myGroup) ? null : myGroup)
+          .withVersion(myVersion)
+          .withKind(myKind)
+          .withPlural(myPlural)
+          .withNamespaced(!myClusterScoped)
+          .build();
+    }
+
+    @NotNull
+    public String getGroup() {
+        return myGroup;
+    }
+
+    @NotNull
+    public String getVersion() {
+        return myVersion;
+    }
+
+    @NotNull
+    public String getKind() {
+        return myKind;
+    }
+
+    @NotNull
+    public String getPlural() {
+        return myPlural;
+    }
+
+    @NotNull
+    public String getApiVersion() {
+        return StringUtil.isEmpty(myGroup) ? myVersion : myGroup + "/" + myVersion;
+    }
+
+    public boolean isClusterScoped() {
+        return myClusterScoped;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CustomResourceContext)) return false;
+        final CustomResourceContext that = (CustomResourceContext)o;
+        return myClusterScoped == that.myClusterScoped &&
+               myGroup.equals(that.myGroup) &&
+               myVersion.equals(that.myVersion) &&
+               myKind.equals(that.myKind) &&
+               myPlural.equals(that.myPlural);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(myGroup, myVersion, myKind, myPlural, myClusterScoped);
+    }
+
+    @Override
+    public String toString() {
+        return "CustomResourceContext{" + getApiVersion() + "/" + myKind + " (" + myPlural + "), clusterScoped=" + myClusterScoped + "}";
+    }
+}

--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/connector/KubeApiConnector.java
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/connector/KubeApiConnector.java
@@ -1,6 +1,7 @@
 
 package jetbrains.buildServer.clouds.kubernetes.connector;
 
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodStatus;
@@ -46,6 +47,18 @@ public interface KubeApiConnector extends Closeable {
     Collection<String> listDeployments();
 
     boolean deletePVC(@NotNull String name);
+
+    /**
+     * Creates a custom resource (e.g. an XSmogVM) of the given type. The resource is created
+     * in the connection's namespace unless the type is cluster-scoped.
+     */
+    @NotNull
+    GenericKubernetesResource createCustomResource(@NotNull CustomResourceContext resourceContext, @NotNull GenericKubernetesResource resource);
+
+    boolean deleteCustomResource(@NotNull CustomResourceContext resourceContext, @NotNull String name);
+
+    @NotNull
+    Collection<GenericKubernetesResource> listCustomResources(@NotNull CustomResourceContext resourceContext, @NotNull Map<String, String> labels);
 
     void invalidate();
 }

--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/connector/KubeApiConnectorImpl.java
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/connector/KubeApiConnectorImpl.java
@@ -2,6 +2,8 @@
 package jetbrains.buildServer.clouds.kubernetes.connector;
 
 import com.intellij.openapi.diagnostic.Logger;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceList;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -11,6 +13,8 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
@@ -62,6 +66,21 @@ public class KubeApiConnectorImpl implements KubeApiConnector {
     @Override
     public KubeApiConnectionCheckResult testConnection() {
         try {
+            // When no namespace is configured explicitly (e.g. a KCP workspace hosting only
+            // cluster-scoped custom resources), checking the implicit "default" namespace is
+            // meaningless - verify API reachability and authentication instead.
+            if (StringUtil.isEmptyOrSpaces(myConnectionSettings.getCustomParameter(jetbrains.buildServer.clouds.kubernetes.KubeParametersConstants.KUBERNETES_NAMESPACE))) {
+                try {
+                    myKubernetesClient.namespaces().list();
+                    return KubeApiConnectionCheckResult.ok("Connection successful");
+                } catch (KubernetesClientException e) {
+                    if (e.getCode() == 403) {
+                        // authenticated but not allowed to list namespaces - the connection itself works
+                        return KubeApiConnectionCheckResult.ok("Connection successful (token is not allowed to list namespaces)");
+                    }
+                    throw e;
+                }
+            }
             String currentNamespaceName = myConfig.getNamespace();
             Namespace currentNamespace = myKubernetesClient.namespaces().withName(currentNamespaceName).get();
             return currentNamespace != null
@@ -140,6 +159,41 @@ public class KubeApiConnectorImpl implements KubeApiConnector {
 
     public boolean deletePVC(@NotNull String name){
         return withKubernetesClient(kubernetesClient -> kubernetesClient.persistentVolumeClaims().withName(name).delete());
+    }
+
+    @NotNull
+    @Override
+    public GenericKubernetesResource createCustomResource(@NotNull CustomResourceContext resourceContext, @NotNull GenericKubernetesResource resource) {
+        return withKubernetesClient(kubernetesClient -> {
+            final MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> operation =
+              kubernetesClient.genericKubernetesResources(resourceContext.toResourceDefinitionContext());
+            return resourceContext.isClusterScoped()
+                   ? operation.create(resource)
+                   : operation.inNamespace(getNamespace()).create(resource);
+        });
+    }
+
+    @Override
+    public boolean deleteCustomResource(@NotNull CustomResourceContext resourceContext, @NotNull String name) {
+        return withKubernetesClient(kubernetesClient -> {
+            final MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> operation =
+              kubernetesClient.genericKubernetesResources(resourceContext.toResourceDefinitionContext());
+            return resourceContext.isClusterScoped()
+                   ? operation.withName(name).delete()
+                   : operation.inNamespace(getNamespace()).withName(name).delete();
+        });
+    }
+
+    @NotNull
+    @Override
+    public Collection<GenericKubernetesResource> listCustomResources(@NotNull CustomResourceContext resourceContext, @NotNull Map<String, String> labels) {
+        return withKubernetesClient(kubernetesClient -> {
+            final MixedOperation<GenericKubernetesResource, GenericKubernetesResourceList, Resource<GenericKubernetesResource>> operation =
+              kubernetesClient.genericKubernetesResources(resourceContext.toResourceDefinitionContext());
+            return resourceContext.isClusterScoped()
+                   ? operation.withLabels(labels).list().getItems()
+                   : operation.inNamespace(getNamespace()).withLabels(labels).list().getItems();
+        });
     }
 
     @Override

--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/podSpec/BuildAgentPodTemplateProvidersImpl.java
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/podSpec/BuildAgentPodTemplateProvidersImpl.java
@@ -20,6 +20,7 @@ public class BuildAgentPodTemplateProvidersImpl implements BuildAgentPodTemplate
         registerProvider(new SimpleRunContainerProvider(serverSettings));
         registerProvider(new DeploymentBuildAgentPodTemplateProvider(serverSettings));
         registerProvider(new CustomTemplatePodTemplateProvider(serverSettings));
+        registerProvider(new CustomResourceTemplateProvider(serverSettings));
     }
 
     @NotNull

--- a/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/podSpec/CustomResourceTemplateProvider.java
+++ b/teamcity-kubernetes-plugin-server/src/main/java/jetbrains/buildServer/clouds/kubernetes/podSpec/CustomResourceTemplateProvider.java
@@ -1,0 +1,138 @@
+
+package jetbrains.buildServer.clouds.kubernetes.podSpec;
+
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import java.io.ByteArrayInputStream;
+import java.util.HashMap;
+import java.util.Map;
+import jetbrains.buildServer.clouds.CloudInstanceUserData;
+import jetbrains.buildServer.clouds.kubernetes.KubeCloudException;
+import jetbrains.buildServer.clouds.kubernetes.KubeCloudImage;
+import jetbrains.buildServer.clouds.kubernetes.KubeTeamCityLabels;
+import jetbrains.buildServer.clouds.kubernetes.connector.CustomResourceContext;
+import jetbrains.buildServer.clouds.kubernetes.connector.KubeApiConnector;
+import jetbrains.buildServer.serverSide.ServerSettings;
+import jetbrains.buildServer.util.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Deploy mode that provisions build agents from a user-supplied custom resource manifest
+ * (e.g. an XSmogVM Crossplane composite in a KCP workspace) instead of a Pod.
+ *
+ * The manifest supports the following placeholders, which the user is expected to wire into
+ * the VM bootstrap (cloud-init / sysprep) so the agent baked into the golden image
+ * self-registers with the matching TeamCity environment variables:
+ * <ul>
+ *   <li>{@code %instance.id%} - generated instance/resource name (must equal env TC_K8S_INSTANCE_NAME)</li>
+ *   <li>{@code %agent.name%}  - agent name (name prefix + instance id)</li>
+ *   <li>{@code %server.url%}  - TeamCity server URL</li>
+ *   <li>{@code %server.uuid%} - TeamCity server UUID (env TC_K8S_SERVER_UUID)</li>
+ *   <li>{@code %profile.id%}  - cloud profile id (env TC_K8S_CLOUD_PROFILE_ID)</li>
+ *   <li>{@code %image.id%}    - cloud image id (env TC_K8S_IMAGE_NAME)</li>
+ * </ul>
+ */
+public class CustomResourceTemplateProvider implements BuildAgentPodTemplateProvider {
+    public static final String ID = "custom-resource";
+
+    private final ServerSettings myServerSettings;
+
+    public CustomResourceTemplateProvider(ServerSettings serverSettings) {
+        myServerSettings = serverSettings;
+    }
+
+    @NotNull
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @NotNull
+    @Override
+    public String getDisplayName() {
+        return "Use custom resource template (VM / KCP)";
+    }
+
+    @Nullable
+    @Override
+    public String getDescription() {
+        return null;
+    }
+
+    @NotNull
+    @Override
+    public Pod getPodTemplate(@NotNull String instanceName,
+                              @NotNull CloudInstanceUserData cloudInstanceUserData,
+                              @NotNull KubeCloudImage kubeCloudImage,
+                              @NotNull KubeApiConnector apiConnector) {
+        throw new KubeCloudException("The custom resource deploy mode does not produce pods");
+    }
+
+    @NotNull
+    public GenericKubernetesResource getResourceTemplate(@NotNull String instanceName,
+                                                         @NotNull CloudInstanceUserData cloudInstanceUserData,
+                                                         @NotNull KubeCloudImage kubeCloudImage,
+                                                         @NotNull KubeApiConnector apiConnector) {
+        String spec = kubeCloudImage.getCustomResourceTemplate();
+        if (StringUtil.isEmpty(spec)) {
+            throw new KubeCloudException("Custom resource template is not specified for image " + kubeCloudImage.getId());
+        }
+        final CustomResourceContext resourceContext = kubeCloudImage.getCustomResourceContext();
+        if (resourceContext == null) {
+            throw new KubeCloudException("Cannot determine the custom resource type for image " + kubeCloudImage.getId());
+        }
+
+        spec = substitutePlaceholders(spec, instanceName, cloudInstanceUserData, kubeCloudImage);
+
+        final GenericKubernetesResource resource = Serialization.unmarshal(
+          new ByteArrayInputStream(spec.getBytes()),
+          GenericKubernetesResource.class
+        );
+
+        if (resource.getMetadata() == null) {
+            resource.setMetadata(new ObjectMeta());
+        }
+        final ObjectMeta metadata = resource.getMetadata();
+        metadata.setName(instanceName);
+        if (!resourceContext.isClusterScoped() && StringUtil.isEmpty(metadata.getNamespace())) {
+            metadata.setNamespace(apiConnector.getNamespace());
+        }
+
+        final Map<String, String> labels = new HashMap<>();
+        if (metadata.getLabels() != null) {
+            labels.putAll(metadata.getLabels());
+        }
+        labels.put(KubeTeamCityLabels.TEAMCITY_AGENT_LABEL, "");
+        labels.put(KubeTeamCityLabels.TEAMCITY_SERVER_UUID, StringUtil.emptyIfNull(myServerSettings.getServerUUID()));
+        labels.put(KubeTeamCityLabels.TEAMCITY_CLOUD_PROFILE, cloudInstanceUserData.getProfileId());
+        labels.put(KubeTeamCityLabels.TEAMCITY_CLOUD_IMAGE, kubeCloudImage.getId());
+        metadata.setLabels(labels);
+
+        return resource;
+    }
+
+    @NotNull
+    private String substitutePlaceholders(@NotNull String spec,
+                                          @NotNull String instanceName,
+                                          @NotNull CloudInstanceUserData cloudInstanceUserData,
+                                          @NotNull KubeCloudImage kubeCloudImage) {
+        return spec
+          .replaceAll("%instance\\.id%", instanceName)
+          .replaceAll("%agent\\.name%", kubeCloudImage.getAgentName(instanceName))
+          .replaceAll("%server\\.url%", cloudInstanceUserData.getServerAddress())
+          .replaceAll("%server\\.uuid%", StringUtil.emptyIfNull(myServerSettings.getServerUUID()))
+          .replaceAll("%profile\\.id%", cloudInstanceUserData.getProfileId())
+          .replaceAll("%image\\.id%", kubeCloudImage.getId());
+    }
+
+    @Nullable
+    @Override
+    public PersistentVolumeClaim getPVC(@NotNull final String instanceName,
+                                        @NotNull final KubeCloudImage kubeCloudImage) {
+        return null;
+    }
+}

--- a/teamcity-kubernetes-plugin-server/src/main/resources/buildServerResources/editProfile.jsp
+++ b/teamcity-kubernetes-plugin-server/src/main/resources/buildServerResources/editProfile.jsp
@@ -159,6 +159,34 @@
                 <span class="error option-error option-error_${cons.customPodTemplate}"></span>
             </td>
         </tr>
+        <tr class="hidden custom-resource pod-spec-ui">
+            <th><label for="${cons.customResourceTemplate}">Custom resource manifest:<l:star/></label></th>
+            <td class="codeHighlightTD">
+                <props:multilineProperty highlight="yaml" expanded="${true}" name="${cons.customResourceTemplate}" rows="10" cols="30"
+                                         linkTitle="Edit the custom resource YAML manifest" className="longField"/>
+                <div class="smallNoteAttention">YAML manifest of the custom resource (e.g. an XSmogVM) that provisions a self-registering VM build agent.
+                    Supported placeholders: %instance.id%, %agent.name%, %server.url%, %server.uuid%, %profile.id%, %image.id%</div>
+                <span class="error option-error option-error_${cons.customResourceTemplate}"></span>
+            </td>
+        </tr>
+        <tr class="hidden custom-resource pod-spec-ui">
+            <th><label for="${cons.customResourceClusterScoped}">Cluster-scoped resource:</label></th>
+            <td>
+                <input type="checkbox" id="${cons.customResourceClusterScoped}"/>
+                <div class="smallNoteAttention">Check if the resource is cluster-scoped (e.g. a Crossplane composite/XR). Leave unchecked for namespaced resources (claims) - the profile namespace is used.</div>
+                <span class="error option-error option-error_${cons.customResourceClusterScoped}"></span>
+            </td>
+        </tr>
+        <tr class="hidden custom-resource pod-spec-ui">
+            <th><label for="${cons.customResourcePlural}">Resource plural:</label></th>
+            <td>
+                <div>
+                    <input type="text" id="${cons.customResourcePlural}" value="" class="longField" data-id="${cons.customResourcePlural}" data-err-id="${cons.customResourcePlural}"/>
+                    <div class="smallNoteAttention">Lowercase plural of the resource kind as registered in the API (e.g. xsmogvms). Leave empty to derive it from the kind.</div>
+                    <span class="error option-error option-error_${cons.customResourcePlural}"></span>
+                </div>
+            </td>
+        </tr>
         <tr class="hidden deployment-base pod-spec-ui">
             <th>Deployment name:&nbsp;<l:star/></th>
             <td>

--- a/teamcity-kubernetes-plugin-server/src/main/resources/buildServerResources/kubeSettings.js
+++ b/teamcity-kubernetes-plugin-server/src/main/resources/buildServerResources/kubeSettings.js
@@ -47,7 +47,8 @@ BS.Kube.ProfileSettingsForm = OO.extend(BS.PluginPropertiesForm, {
         </tr>')
     },
 
-    _dataKeys: [ 'imageDescription', 'dockerImage', 'agent_pool_id', 'imageInstanceLimit', 'customPodTemplate', 'podTemplateMode', 'sourceDeployment', 'agentNamePrefix' ],
+    _dataKeys: [ 'imageDescription', 'dockerImage', 'agent_pool_id', 'imageInstanceLimit', 'customPodTemplate', 'podTemplateMode', 'sourceDeployment', 'agentNamePrefix',
+                 'customResourceTemplate', 'customResourceClusterScoped', 'customResourcePlural' ],
 
     selectors: {
         rmImageLink: '.removeVmImageLink',
@@ -95,6 +96,9 @@ BS.Kube.ProfileSettingsForm = OO.extend(BS.PluginPropertiesForm, {
         this.$dockerArgs = $j('#dockerArgs');
         this.$deploymentName = $j('#sourceDeployment');
         this.$customPodTemplate = $j('#customPodTemplate');
+        this.$customResourceTemplate = $j('#customResourceTemplate');
+        this.$customResourceClusterScoped = $j('#customResourceClusterScoped');
+        this.$customResourcePlural = $j('#customResourcePlural');
         this.$agentNamePrefix = $j('#agentNamePrefix');
         this.$imageInstanceLimit = $j('#imageInstanceLimit');
         this.$agentPoolSelector = $j('#agent_pool_id');
@@ -245,6 +249,36 @@ BS.Kube.ProfileSettingsForm = OO.extend(BS.PluginPropertiesForm, {
         .on('cm-change', function(e, value){
             self._image[this.getAttribute('id')] = value;
         });
+
+        this.$customResourceTemplate
+        .on('change', function(e, data){
+            var val = e.target.value;
+            if (arguments.length === 1) {
+                self._image[this.getAttribute('id')] = val;
+            } else {
+                this.value = data;
+                $j(this).trigger('cm-set-value', data);
+            }
+        })
+        .on('cm-change', function(e, value){
+            self._image[this.getAttribute('id')] = value;
+        });
+
+        this.$customResourceClusterScoped.on('change', function (e, value) {
+            if (arguments.length === 1) {
+                this._image['customResourceClusterScoped'] = this.$customResourceClusterScoped.is(':checked') ? 'true' : '';
+            } else {
+                this.$customResourceClusterScoped.prop('checked', value === 'true');
+            }
+        }.bind(this));
+
+        this.$customResourcePlural.on('change', function (e, value) {
+            if (arguments.length === 1) {
+                this._image['customResourcePlural'] = this.$customResourcePlural.val();
+            } else {
+                this.$customResourcePlural.val(value);
+            }
+        }.bind(this));
     },
 
     _updateImageDescription: function (image) {
@@ -254,6 +288,9 @@ BS.Kube.ProfileSettingsForm = OO.extend(BS.PluginPropertiesForm, {
             switch (podSpecMode){
                 case 'custom-pod-template':
                     imageDescription = 'Custom pod template: ' + image['agentNamePrefix'];
+                    break;
+                case 'custom-resource':
+                    imageDescription = 'Custom resource (VM): ' + image['agentNamePrefix'];
                     break;
                 case 'deployment-base':
                     imageDescription = 'Use deployment: ' + image['sourceDeployment'];
@@ -426,7 +463,7 @@ BS.Kube.ProfileSettingsForm = OO.extend(BS.PluginPropertiesForm, {
             }.bind(this),
 
             agentNamePrefix: function(){
-                if (this._image['podTemplateMode'] === 'custom-pod-template' && !this._image['agentNamePrefix']) {
+                if ((this._image['podTemplateMode'] === 'custom-pod-template' || this._image['podTemplateMode'] === 'custom-resource') && !this._image['agentNamePrefix']) {
                     this.addOptionError('required', 'agentNamePrefix');
                     isValid = false;
                 } else if (this._image['agentNamePrefix']){
@@ -457,6 +494,14 @@ BS.Kube.ProfileSettingsForm = OO.extend(BS.PluginPropertiesForm, {
                 var valueToValidate = this._image['customPodTemplate'];
                 if (this._image['podTemplateMode'] === 'custom-pod-template' && (!valueToValidate || valueToValidate === '')) {
                     this.addOptionError('required', 'customPodTemplate');
+                    isValid = false;
+                }
+            }.bind(this),
+
+            customResourceTemplate : function () {
+                var valueToValidate = this._image['customResourceTemplate'];
+                if (this._image['podTemplateMode'] === 'custom-resource' && (!valueToValidate || valueToValidate === '')) {
+                    this.addOptionError('required', 'customResourceTemplate');
                     isValid = false;
                 }
             }.bind(this)
@@ -571,6 +616,8 @@ BS.Kube.ProfileSettingsForm = OO.extend(BS.PluginPropertiesForm, {
         this.$agentNamePrefix.trigger('change', image['agentNamePrefix'] || '');
         this.$imageInstanceLimit.trigger('change', image['imageInstanceLimit'] || '');
         this.$agentPoolSelector.trigger('change', image['agent_pool_id'] || '');
+        this.$customResourceClusterScoped.trigger('change', image['customResourceClusterScoped'] || '');
+        this.$customResourcePlural.trigger('change', image['customResourcePlural'] || '');
 
         BS.Kube.ImageDialog.showCentered();
         this._resetCodeMirrorValues();
@@ -664,6 +711,9 @@ BS.Kube.ProfileSettingsForm = OO.extend(BS.PluginPropertiesForm, {
         this.$imageInstanceLimit.trigger('change', '');
         this.$agentPoolSelector.trigger('change', '');
         this.$customPodTemplate.trigger('change', '');
+        this.$customResourceTemplate.trigger('change', '');
+        this.$customResourceClusterScoped.trigger('change', '');
+        this.$customResourcePlural.trigger('change', '');
     },
 
     _resetCodeMirrorValues: function () {
@@ -671,6 +721,7 @@ BS.Kube.ProfileSettingsForm = OO.extend(BS.PluginPropertiesForm, {
       // waiting for CodeMirror to be attached
       setTimeout(() => {
         this.$customPodTemplate.trigger('change', this._image['customPodTemplate'] || '');
+        this.$customResourceTemplate.trigger('change', this._image['customResourceTemplate'] || '');
       }, 0);
     }
 });

--- a/teamcity-kubernetes-plugin-server/src/test/java/jetbrains/buildServer/clouds/kubernetes/CustomResourceTemplateProviderTest.java
+++ b/teamcity-kubernetes-plugin-server/src/test/java/jetbrains/buildServer/clouds/kubernetes/CustomResourceTemplateProviderTest.java
@@ -1,0 +1,120 @@
+package jetbrains.buildServer.clouds.kubernetes;
+
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import java.util.Collections;
+import java.util.Map;
+import jetbrains.buildServer.BaseTestCase;
+import jetbrains.buildServer.clouds.CloudImageParameters;
+import jetbrains.buildServer.clouds.CloudInstanceUserData;
+import jetbrains.buildServer.clouds.kubernetes.connector.FakeKubeApiConnector;
+import jetbrains.buildServer.clouds.kubernetes.connector.KubeApiConnector;
+import jetbrains.buildServer.clouds.kubernetes.podSpec.CustomResourceTemplateProvider;
+import jetbrains.buildServer.clouds.server.impl.profile.CloudImageDataImpl;
+import jetbrains.buildServer.clouds.server.impl.profile.CloudImageParametersImpl;
+import jetbrains.buildServer.serverSide.ServerResponsibilityImpl;
+import jetbrains.buildServer.serverSide.ServerSettings;
+import jetbrains.buildServer.serverSide.impl.ServerSettingsImpl;
+import jetbrains.buildServer.serverSide.impl.auth.SecurityContextImpl;
+import org.jetbrains.annotations.NotNull;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+@SuppressWarnings("unchecked")
+@Test
+public class CustomResourceTemplateProviderTest extends BaseTestCase {
+    private static final String PROJECT_ID = "project123";
+    private static final String TEMPLATE =
+      "apiVersion: smog.example.io/v1alpha1\n" +
+      "kind: XSmogVM\n" +
+      "metadata:\n" +
+      "  labels:\n" +
+      "    custom: label\n" +
+      "spec:\n" +
+      "  image: windows-golden\n" +
+      "  userData: |\n" +
+      "    serverUrl=%server.url%\n" +
+      "    serverUuid=%server.uuid%\n" +
+      "    profileId=%profile.id%\n" +
+      "    imageId=%image.id%\n" +
+      "    instanceId=%instance.id%\n" +
+      "    agentName=%agent.name%\n";
+
+    private CustomResourceTemplateProvider myProvider;
+    private KubeApiConnector myApiConnector;
+
+    @BeforeMethod
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        final ServerSettings serverSettings = new ServerSettingsImpl(new SecurityContextImpl(new ServerResponsibilityImpl())) {
+            @NotNull
+            @Override
+            public String getServerUUID() {
+                return "SERVER-UUID";
+            }
+        };
+        myProvider = new CustomResourceTemplateProvider(serverSettings);
+        myApiConnector = new FakeKubeApiConnector() {
+            @Override
+            public String getNamespace() {
+                return "ns1";
+            }
+        };
+    }
+
+    public void substitutes_placeholders_and_injects_labels() {
+        final KubeCloudImage image = createImage(false);
+
+        final GenericKubernetesResource resource = myProvider.getResourceTemplate("vm-agent-1", createInstanceTag(), image, myApiConnector);
+
+        then(resource.getApiVersion()).isEqualTo("smog.example.io/v1alpha1");
+        then(resource.getKind()).isEqualTo("XSmogVM");
+        then(resource.getMetadata().getName()).isEqualTo("vm-agent-1");
+        then(resource.getMetadata().getNamespace()).isEqualTo("ns1");
+        then(resource.getMetadata().getLabels())
+          .containsEntry("custom", "label")
+          .containsEntry(KubeTeamCityLabels.TEAMCITY_CLOUD_IMAGE, "image1")
+          .containsEntry(KubeTeamCityLabels.TEAMCITY_CLOUD_PROFILE, "profile id")
+          .containsEntry(KubeTeamCityLabels.TEAMCITY_SERVER_UUID, "SERVER-UUID")
+          .containsKey(KubeTeamCityLabels.TEAMCITY_AGENT_LABEL);
+
+        final Map<String, Object> spec = (Map<String, Object>)resource.getAdditionalProperties().get("spec");
+        then(spec.get("image")).isEqualTo("windows-golden");
+        final String userData = (String)spec.get("userData");
+        then(userData)
+          .contains("serverUrl=server address")
+          .contains("serverUuid=SERVER-UUID")
+          .contains("profileId=profile id")
+          .contains("imageId=image1")
+          .contains("instanceId=vm-agent-1")
+          .contains("agentName=vm-vm-agent-1");
+    }
+
+    public void cluster_scoped_resource_gets_no_namespace() {
+        final KubeCloudImage image = createImage(true);
+
+        final GenericKubernetesResource resource = myProvider.getResourceTemplate("vm-agent-1", createInstanceTag(), image, myApiConnector);
+
+        then(resource.getMetadata().getNamespace()).isNull();
+    }
+
+    private KubeCloudImage createImage(boolean clusterScoped) {
+        final Map<String, String> params = createMap(
+          CloudImageParameters.SOURCE_ID_FIELD, "image1",
+          KubeParametersConstants.POD_TEMPLATE_MODE, CustomResourceTemplateProvider.ID,
+          KubeParametersConstants.CUSTOM_RESOURCE_TEMPLATE, TEMPLATE,
+          KubeParametersConstants.CUSTOM_RESOURCE_CLUSTER_SCOPED, String.valueOf(clusterScoped),
+          KubeParametersConstants.AGENT_NAME_PREFIX, "vm-");
+        return new KubeCloudImageImpl(
+          new KubeCloudImageData(new CloudImageParametersImpl(new CloudImageDataImpl(params), PROJECT_ID, "image1")),
+          myApiConnector
+        );
+    }
+
+    private CloudInstanceUserData createInstanceTag() {
+        return new CloudInstanceUserData("agent name", "auth token", "server address", null, "profile id", "profile description",
+                                         Collections.singletonMap(KubeContainerEnvironment.STARTING_INSTANCE_ID_PARAM, "token"));
+    }
+}

--- a/teamcity-kubernetes-plugin-server/src/test/java/jetbrains/buildServer/clouds/kubernetes/KubeCloudCustomResourceInstanceTest.java
+++ b/teamcity-kubernetes-plugin-server/src/test/java/jetbrains/buildServer/clouds/kubernetes/KubeCloudCustomResourceInstanceTest.java
@@ -1,0 +1,93 @@
+package jetbrains.buildServer.clouds.kubernetes;
+
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import jetbrains.buildServer.BaseTestCase;
+import jetbrains.buildServer.clouds.CloudImageParameters;
+import jetbrains.buildServer.clouds.InstanceStatus;
+import jetbrains.buildServer.clouds.kubernetes.connector.FakeKubeApiConnector;
+import jetbrains.buildServer.clouds.kubernetes.podSpec.CustomResourceTemplateProvider;
+import jetbrains.buildServer.clouds.server.impl.profile.CloudImageDataImpl;
+import jetbrains.buildServer.clouds.server.impl.profile.CloudImageParametersImpl;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+@Test
+public class KubeCloudCustomResourceInstanceTest extends BaseTestCase {
+
+    public void starts_scheduled_then_starting_without_conditions() {
+        final KubeCloudCustomResourceInstance instance = createInstance();
+        then(instance.getStatus()).isEqualTo(InstanceStatus.SCHEDULED_TO_START);
+
+        instance.updateState(resource("vm-1", null));
+        then(instance.getStatus()).isEqualTo(InstanceStatus.STARTING);
+    }
+
+    public void ready_condition_marks_running() {
+        final KubeCloudCustomResourceInstance instance = createInstance();
+        instance.updateState(resource("vm-1", condition("Ready", "True", null, null)));
+        then(instance.getStatus()).isEqualTo(InstanceStatus.RUNNING);
+        then(instance.getErrorInfo()).isNull();
+    }
+
+    public void agent_registration_running_is_not_downgraded() {
+        final KubeCloudCustomResourceInstance instance = createInstance();
+        instance.setStatus(InstanceStatus.RUNNING); // set when the agent registered
+        instance.updateState(resource("vm-1", condition("Ready", "False", "Creating", null)));
+        then(instance.getStatus()).isEqualTo(InstanceStatus.RUNNING);
+    }
+
+    public void synced_false_surfaces_error() {
+        final KubeCloudCustomResourceInstance instance = createInstance();
+        instance.updateState(resource("vm-1", condition("Synced", "False", "ReconcileError", "composition not found")));
+        then(instance.getErrorInfo()).isNotNull();
+        then(instance.getErrorInfo().getDetailedMessage()).contains("composition not found");
+    }
+
+    public void terminating_instance_status_is_not_overwritten() {
+        final KubeCloudCustomResourceInstance instance = createInstance();
+        instance.setStatus(InstanceStatus.SCHEDULED_TO_STOP);
+        instance.updateState(resource("vm-1", condition("Ready", "True", null, null)));
+        then(instance.getStatus()).isEqualTo(InstanceStatus.SCHEDULED_TO_STOP);
+    }
+
+    private KubeCloudCustomResourceInstance createInstance() {
+        final Map<String, String> params = createMap(
+          CloudImageParameters.SOURCE_ID_FIELD, "image1",
+          KubeParametersConstants.POD_TEMPLATE_MODE, CustomResourceTemplateProvider.ID,
+          KubeParametersConstants.AGENT_NAME_PREFIX, "vm-");
+        final KubeCloudImage image = new KubeCloudImageImpl(
+          new KubeCloudImageData(new CloudImageParametersImpl(new CloudImageDataImpl(params), "project123", "image1")),
+          new FakeKubeApiConnector()
+        );
+        return new KubeCloudCustomResourceInstance(image, resource("vm-1", null));
+    }
+
+    private static GenericKubernetesResource resource(String name, Map<String, Object> condition) {
+        final GenericKubernetesResource resource = new GenericKubernetesResource();
+        resource.setApiVersion("smog.example.io/v1alpha1");
+        resource.setKind("XSmogVM");
+        final ObjectMeta metadata = new ObjectMeta();
+        metadata.setName(name);
+        resource.setMetadata(metadata);
+        if (condition != null) {
+            final Map<String, Object> status = new HashMap<>();
+            status.put("conditions", Arrays.asList(condition));
+            resource.setAdditionalProperty("status", status);
+        }
+        return resource;
+    }
+
+    private static Map<String, Object> condition(String type, String status, String reason, String message) {
+        final Map<String, Object> condition = new HashMap<>();
+        condition.put("type", type);
+        condition.put("status", status);
+        if (reason != null) condition.put("reason", reason);
+        if (message != null) condition.put("message", message);
+        return condition;
+    }
+}

--- a/teamcity-kubernetes-plugin-server/src/test/java/jetbrains/buildServer/clouds/kubernetes/connector/CustomResourceContextTest.java
+++ b/teamcity-kubernetes-plugin-server/src/test/java/jetbrains/buildServer/clouds/kubernetes/connector/CustomResourceContextTest.java
@@ -1,0 +1,73 @@
+package jetbrains.buildServer.clouds.kubernetes.connector;
+
+import jetbrains.buildServer.BaseTestCase;
+import jetbrains.buildServer.clouds.kubernetes.KubeCloudException;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.testng.Assert.fail;
+
+@Test
+public class CustomResourceContextTest extends BaseTestCase {
+
+    public void parse_group_version_kind_from_template() {
+        final CustomResourceContext context = CustomResourceContext.fromTemplate(
+          "apiVersion: smog.example.io/v1alpha1\n" +
+          "kind: XSmogVM\n" +
+          "spec:\n" +
+          "  image: windows-golden\n",
+          true, null);
+
+        then(context.getGroup()).isEqualTo("smog.example.io");
+        then(context.getVersion()).isEqualTo("v1alpha1");
+        then(context.getKind()).isEqualTo("XSmogVM");
+        then(context.getPlural()).isEqualTo("xsmogvms");
+        then(context.getApiVersion()).isEqualTo("smog.example.io/v1alpha1");
+        then(context.isClusterScoped()).isTrue();
+    }
+
+    public void parse_core_group() {
+        final CustomResourceContext context = CustomResourceContext.fromTemplate(
+          "apiVersion: v1\nkind: ConfigMap\n", false, null);
+
+        then(context.getGroup()).isEmpty();
+        then(context.getVersion()).isEqualTo("v1");
+        then(context.getApiVersion()).isEqualTo("v1");
+        then(context.isClusterScoped()).isFalse();
+    }
+
+    public void plural_override_wins() {
+        final CustomResourceContext context = CustomResourceContext.fromTemplate(
+          "apiVersion: smog.example.io/v1alpha1\nkind: XSmogVM\n", true, "XSmogVMs");
+
+        then(context.getPlural()).isEqualTo("xsmogvms");
+    }
+
+    public void missing_kind_fails() {
+        try {
+            CustomResourceContext.fromTemplate("apiVersion: v1\n", false, null);
+            fail("expected KubeCloudException");
+        } catch (KubeCloudException e) {
+            then(e.getMessage()).contains("kind");
+        }
+    }
+
+    public void invalid_yaml_fails() {
+        try {
+            CustomResourceContext.fromTemplate("{{{not yaml", false, null);
+            fail("expected KubeCloudException");
+        } catch (KubeCloudException ignored) {
+        }
+    }
+
+    public void resource_definition_context_is_built() {
+        final CustomResourceContext context = CustomResourceContext.fromTemplate(
+          "apiVersion: smog.example.io/v1alpha1\nkind: XSmogVM\n", true, null);
+        final io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext rdc = context.toResourceDefinitionContext();
+
+        then(rdc.getGroup()).isEqualTo("smog.example.io");
+        then(rdc.getVersion()).isEqualTo("v1alpha1");
+        then(rdc.getPlural()).isEqualTo("xsmogvms");
+        then(rdc.isNamespaceScoped()).isFalse();
+    }
+}

--- a/teamcity-kubernetes-plugin-server/src/test/java/jetbrains/buildServer/clouds/kubernetes/connector/FakeKubeApiConnector.java
+++ b/teamcity-kubernetes-plugin-server/src/test/java/jetbrains/buildServer/clouds/kubernetes/connector/FakeKubeApiConnector.java
@@ -1,11 +1,13 @@
 
 package jetbrains.buildServer.clouds.kubernetes.connector;
 
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodStatus;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import okhttp3.OkHttpClient;
 import org.jetbrains.annotations.NotNull;
@@ -76,6 +78,23 @@ public class FakeKubeApiConnector implements KubeApiConnector {
   @Override
   public boolean deletePVC(@NotNull final String name) {
     return false;
+  }
+
+  @NotNull
+  @Override
+  public GenericKubernetesResource createCustomResource(@NotNull final CustomResourceContext resourceContext, @NotNull final GenericKubernetesResource resource) {
+    return resource;
+  }
+
+  @Override
+  public boolean deleteCustomResource(@NotNull final CustomResourceContext resourceContext, @NotNull final String name) {
+    return false;
+  }
+
+  @NotNull
+  @Override
+  public Collection<GenericKubernetesResource> listCustomResources(@NotNull final CustomResourceContext resourceContext, @NotNull final Map<String, String> labels) {
+    return Collections.emptyList();
   }
 
   @Override


### PR DESCRIPTION
Add a fourth deploy mode that provisions build agents by creating arbitrary custom resources (e.g. XSmogVM Crossplane composites in a KCP workspace) instead of Pods, enabling ephemeral VM build agents:

- KubeApiConnector: generic create/delete/list for custom resources via fabric8 genericKubernetesResources; GVK derived from the manifest's apiVersion/kind (CustomResourceContext), cluster-scoped or namespaced
- CustomResourceTemplateProvider: new 'custom-resource' image mode with placeholder substitution (%instance.id%, %agent.name%, %server.url%, %server.uuid%, %profile.id%, %image.id%) and TeamCity label injection
- KubeCloudCustomResourceInstance: CR-backed instance; RUNNING when the agent registers on the server (KubeBackgroundUpdaterImpl listener) or on Crossplane Ready=True; Synced=False surfaced as instance error
- KubeCloudClient/KubeCloudImageImpl: start/terminate/populate branches for custom-resource images
- testConnection: with no explicit namespace, verify API reachability and auth instead of requiring a namespace (KCP workspaces, 403-tolerant)
- UI: manifest editor, cluster-scoped checkbox, plural override
- docs: DESIGN-xsmogvm-kcp, PoC-oidc-kcp, BUILD-AND-INTEGRATION

Built against TeamCity 2025.11 API; new TestNG tests for GVK parsing, template provider and instance state mapping.